### PR TITLE
Feature/update settings for deployment

### DIFF
--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -6,7 +6,6 @@ requests
 redis==2.9.0
 django-redis-cache==0.10.2
 hiredis==0.1.2
-django-redis-sessions==0.4.0
 django-cached-authentication-middleware>=0.2.0
 django-angular==0.7.13
 dj-static==0.0.6

--- a/lti_emailer/requirements/demo.txt
+++ b/lti_emailer/requirements/demo.txt
@@ -5,7 +5,6 @@
  
 # below are requirements specific to the stage environment
 
-gunicorn
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.1#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.4#egg=django-icommons-ui
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v0.8#egg=django-auth-lti

--- a/lti_emailer/requirements/production.txt
+++ b/lti_emailer/requirements/production.txt
@@ -5,7 +5,6 @@
  
 # below are requirements specific to the production environment
 
-gunicorn
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.1#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.4#egg=django-icommons-ui
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v0.8#egg=django-auth-lti

--- a/lti_emailer/requirements/qa.txt
+++ b/lti_emailer/requirements/qa.txt
@@ -5,7 +5,6 @@
  
 # below are requirements specific to the qa environment
 
-gunicorn
 oauthlib
 requests-oauthlib
 

--- a/lti_emailer/requirements/test.txt
+++ b/lti_emailer/requirements/test.txt
@@ -5,7 +5,6 @@
  
 # below are requirements specific to the test environment
 
-gunicorn
 oauthlib
 requests-oauthlib
 

--- a/lti_emailer/settings/base.py
+++ b/lti_emailer/settings/base.py
@@ -24,11 +24,14 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fil
 SECRET_KEY = SECURE_SETTINGS.get('django_secret_key', 'changeme')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = SECURE_SETTINGS.get('enable_debug', False)
 
-ALLOWED_HOSTS = []
+TEMPLATE_DEBUG = DEBUG
 
-ADMINS = SECURE_SETTINGS.get('admins')
+ALLOWED_HOSTS = ['*']
+
+# These addresses will receive emails about certain errors
+ADMINS = ()
 
 # Application definition
 
@@ -43,6 +46,7 @@ INSTALLED_APPS = (
     'djangular',
     'lti_emailer',
     'mailing_list',
+    'gunicorn',
     'huey.djhuey'
 )
 
@@ -102,12 +106,12 @@ DATABASE_ROUTERS = ['lti_emailer.routers.DatabaseAppsRouter']
 
 DATABASES = {
     'default': {
-        'ENGINE': SECURE_SETTINGS.get('db_default_backend', 'django.db.backends.sqlite3'),
-        'NAME': SECURE_SETTINGS.get('db_default_name', os.path.join(BASE_DIR, 'db.sqlite3')),
-        'USER': SECURE_SETTINGS.get('db_default_user', None),
-        'PASSWORD': SECURE_SETTINGS.get('db_default_password', None),
-        'HOST': SECURE_SETTINGS.get('db_default_host', None),
-        'PORT': SECURE_SETTINGS.get('db_default_port', None),
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': SECURE_SETTINGS.get('db_default_name', 'lti_emailer'),
+        'USER': SECURE_SETTINGS.get('db_default_user', 'postgres'),
+        'PASSWORD': SECURE_SETTINGS.get('db_default_password'),
+        'HOST': SECURE_SETTINGS.get('db_default_host', '127.0.0.1'),
+        'PORT': SECURE_SETTINGS.get('db_default_port', 5432),  # Default postgres port
     },
     'termtool': {
         'ENGINE': 'django.db.backends.oracle',
@@ -157,18 +161,24 @@ CACHES = {
     },
 }
 
-SESSION_ENGINE = 'redis_sessions.session'
-SESSION_REDIS_HOST = REDIS_HOST
-SESSION_REDIS_PORT = REDIS_PORT
+# Provide a unique value for sharing cache among Django projects
+KEY_PREFIX = 'lti_emailer'
+
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
+
+# Django defaults to False (as of 1.7)
+SESSION_COOKIE_SECURE = SECURE_SETTINGS.get('use_secure_cookies', False)
 
 LTI_OAUTH_CREDENTIALS = SECURE_SETTINGS.get('lti_oauth_credentials', None)
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
+CANVAS_URL = SECURE_SETTINGS.get('canvas_url', 'https://canvas.instructure.com')
+
 CANVAS_SDK_SETTINGS = {
     'auth_token': SECURE_SETTINGS.get('canvas_token', None),
-    'base_api_url': SECURE_SETTINGS.get('canvas_api_url', 'https://canvas.icommons.harvard.edu/api'),
+    'base_api_url': CANVAS_URL + '/api',
     'max_retries': 3,
     'per_page': 40,
     'session_inactivity_expiration_time_secs': 50,
@@ -178,7 +188,7 @@ ICOMMONS_COMMON = {
     'ICOMMONS_API_HOST': SECURE_SETTINGS.get('icommons_api_host', None),
     'ICOMMONS_API_USER': SECURE_SETTINGS.get('icommons_api_user', None),
     'ICOMMONS_API_PASS': SECURE_SETTINGS.get('icommons_api_pass', None),
-    'CANVAS_API_BASE_URL': 'https://canvas.icommons.harvard.edu/api/v1',
+    'CANVAS_API_BASE_URL': CANVAS_URL + '/api/v1',
     'CANVAS_API_HEADERS': {
         'Authorization': 'Bearer ' + SECURE_SETTINGS.get('canvas_token', 'canvas_token_missing_from_config')
     },
@@ -191,13 +201,12 @@ LISTSERV_API_KEY = SECURE_SETTINGS.get('listserv_api_key')
 LISTSERV_ADDRESS_FORMAT = "canvas-{canvas_course_id}-{section_id}@%s" % LISTSERV_DOMAIN
 LISTSERV_PERIODIC_SYNC_CRONTAB = SECURE_SETTINGS.get('listserv_periodic_sync_crontab',
                                                      {'minute': '0'})
-
 CACHE_KEY_LISTS_BY_CANVAS_COURSE_ID = "mailing_lists_by_canvas_course_id-%s"
 
 HUEY = {
     'backend': 'huey.backends.redis_backend',
     'connection': {'host': REDIS_HOST, 'port': REDIS_PORT},
-    'consumer_options': {'workers': 4}, # probably needs tweaking
+    'consumer_options': {'workers': 4},  # probably needs tweaking
     'name': 'mailing list management',
 }
 
@@ -238,7 +247,7 @@ LOGGING = {
         'request': {
             'level': 'DEBUG',
             'class': 'logging.handlers.WatchedFileHandler',
-            'filename': 'request.log',
+            'filename': os.path.join(SECURE_SETTINGS.get('log_root', ''), 'lti_emailer.log'),
             'formatter': 'verbose',
         },
 

--- a/lti_emailer/settings/base.py
+++ b/lti_emailer/settings/base.py
@@ -147,6 +147,8 @@ USE_TZ = True
 
 STATIC_URL = '/lti_emailer/static/'
 
+STATIC_ROOT = os.path.normpath(os.path.join(BASE_DIR, 'http_static'))
+
 REDIS_HOST = SECURE_SETTINGS.get('redis_host', '127.0.0.1')
 REDIS_PORT = SECURE_SETTINGS.get('redis_port', 6379)
 

--- a/lti_emailer/settings/demo.py
+++ b/lti_emailer/settings/demo.py
@@ -1,12 +1,1 @@
 from .base import *
-
-ENV_NAME = 'test'
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
-
-TEMPLATE_DEBUG = False
-
-ALLOWED_HOSTS = ['*']
-
-SESSION_COOKIE_SECURE = True

--- a/lti_emailer/settings/production.py
+++ b/lti_emailer/settings/production.py
@@ -1,17 +1,4 @@
 from .base import *
 
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
-
-TEMPLATE_DEBUG = False
-
-ALLOWED_HOSTS = ['*']
-
-INSTALLED_APPS += ('gunicorn',)
-
-GUNICORN_CONFIG = 'gunicorn_prod.py'
-
-SESSION_COOKIE_SECURE = True
-
 # Allow the mailing_list app to allow any user to be added to listserv
 IGNORE_WHITELIST = True

--- a/lti_emailer/settings/qa.py
+++ b/lti_emailer/settings/qa.py
@@ -1,12 +1,1 @@
 from .base import *
-
-ENV_NAME = 'test'
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
-
-TEMPLATE_DEBUG = False
-
-ALLOWED_HOSTS = ['*']
-
-SESSION_COOKIE_SECURE = True

--- a/lti_emailer/settings/secure.py.example
+++ b/lti_emailer/settings/secure.py.example
@@ -2,10 +2,12 @@
 # and copy this file to secure.py
 
 SECURE_SETTINGS = {
+    'enable_debug': '{{ secure_settings.enable_debug }}',
     'canvas_token': '{{ secure_settings.canvas_token }}',
-    'lti_oauth_credentials': {
-        '{{ secure_settings.lti_key }}': '{{ secure_settings.lti_secret }}',
-    },
+    'canvas_url': '{{ secure_settings.canvas_url }}',
+
+    # A dictionary of key/values for credentials 
+    'lti_oauth_credentials': '{{ secure_settings.lti_oauth_credentials }}',
 
     'icommons_api_user': '{{ secure_settings.icommons_api_user }}',
     'icommons_api_pass': '{{ secure_settings.icommons_api_pass }}',
@@ -13,11 +15,6 @@ SECURE_SETTINGS = {
 
     'django_secret_key': '{{ secure_settings.django_secret_key }}',
 
-    'admins': (
-        ('{{ secure_settings.admin_user_name }}', '{{ secure_settings.admin_user_email }}'),
-    ),
-
-    'db_default_backend': '{{ secure_settings.db_default_backend }}',
     'db_default_name': '{{ secure_settings.db_default_name }}',
     'db_default_user': '{{ secure_settings.db_default_user }}',
     'db_default_password': '{{ secure_settings.db_default_password }}',

--- a/lti_emailer/settings/test.py
+++ b/lti_emailer/settings/test.py
@@ -1,12 +1,1 @@
 from .base import *
-
-ENV_NAME = 'test'
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
-
-TEMPLATE_DEBUG = False
-
-ALLOWED_HOSTS = ['*']
-
-SESSION_COOKIE_SECURE = True

--- a/lti_emailer/urls.py
+++ b/lti_emailer/urls.py
@@ -3,8 +3,8 @@ from django.conf.urls import patterns, include, url
 
 urlpatterns = patterns(
     '',
-    url(r'^lti_auth_error/', 'lti_emailer.views.lti_auth_error', name='lti_auth_error'),
-    url(r'^tool_config$', 'lti_emailer.views.tool_config', name='tool_config'),
-    url(r'^lti_launch$', 'lti_emailer.views.lti_launch', name='lti_launch'),
-    url(r'^mailing_list/', include('mailing_list.urls', namespace='mailing_list')),
+    url(r'^lti_emailer/lti_auth_error/', 'lti_emailer.views.lti_auth_error', name='lti_auth_error'),
+    url(r'^lti_emailer/tool_config$', 'lti_emailer.views.tool_config', name='tool_config'),
+    url(r'^lti_emailer/lti_launch$', 'lti_emailer.views.lti_launch', name='lti_launch'),
+    url(r'^lti_emailer/mailing_list/', include('mailing_list.urls', namespace='mailing_list')),
 )

--- a/lti_emailer/urls.py
+++ b/lti_emailer/urls.py
@@ -3,8 +3,8 @@ from django.conf.urls import patterns, include, url
 
 urlpatterns = patterns(
     '',
-    url(r'^lti_emailer/lti_auth_error/', 'lti_emailer.views.lti_auth_error', name='lti_auth_error'),
-    url(r'^lti_emailer/tool_config$', 'lti_emailer.views.tool_config', name='tool_config'),
-    url(r'^lti_emailer/lti_launch$', 'lti_emailer.views.lti_launch', name='lti_launch'),
-    url(r'^lti_emailer/mailing_list/', include('mailing_list.urls', namespace='mailing_list')),
+    url(r'^lti_auth_error/', 'lti_emailer.views.lti_auth_error', name='lti_auth_error'),
+    url(r'^tool_config$', 'lti_emailer.views.tool_config', name='tool_config'),
+    url(r'^lti_launch$', 'lti_emailer.views.lti_launch', name='lti_launch'),
+    url(r'^mailing_list/', include('mailing_list.urls', namespace='mailing_list')),
 )


### PR DESCRIPTION
Hardcode default db backend to postgres. Add cookie and environment secure settings. Update canvas api url to be base canvas url for reuse opportunity with other projects. Add a cache key_prefix. Use django cache backend for sessions instead of redis_sessions backend (since cache backend is already redis). Add log_root setting. Add STATIC_ROOT.  Remove gunicorn double requirement.  Simplify other environment setting files. Update secure.py example file.