### PR TITLE
Sprint 21 Upgrade django-auth-lti requirement to v0.9

### DIFF
--- a/lti_emailer/requirements/demo.txt
+++ b/lti_emailer/requirements/demo.txt
@@ -7,4 +7,4 @@
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.1#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.4#egg=django-icommons-ui
-git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v0.8#egg=django-auth-lti
+git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v0.9#egg=django-auth-lti

--- a/lti_emailer/requirements/production.txt
+++ b/lti_emailer/requirements/production.txt
@@ -7,4 +7,4 @@
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.1#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.4#egg=django-icommons-ui
-git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v0.8#egg=django-auth-lti
+git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v0.9#egg=django-auth-lti

--- a/lti_emailer/requirements/qa.txt
+++ b/lti_emailer/requirements/qa.txt
@@ -10,4 +10,4 @@ requests-oauthlib
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.1#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.4#egg=django-icommons-ui
-git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v0.8#egg=django-auth-lti
+git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v0.9#egg=django-auth-lti


### PR DESCRIPTION
@rascalking 

django-auth-lti v0.9 gets us the  lis_person_sourcedid LTI parameter which is used to populate audit fields in the lti_emailer models.