### PR TITLE
Sprint 21 Remove gunicorn from installed apps

### DIFF
--- a/lti_emailer/settings/base.py
+++ b/lti_emailer/settings/base.py
@@ -46,7 +46,6 @@ INSTALLED_APPS = (
     'djangular',
     'lti_emailer',
     'mailing_list',
-    'gunicorn',
     'huey.djhuey'
 )
 


### PR DESCRIPTION
@bermudezjd 

This was causing a module conflict with the gunicorn.py script generated by the deployment process.