### PR TITLE
Use CourseSchemaDatabaseRouter to prevent migrations for non-test env…

### DIFF
--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -11,4 +11,5 @@ django-angular==0.7.13
 dj-static==0.0.6
 huey
 
-git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.7.2#egg=canvas-python-sdk
+git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.7.6#egg=canvas-python-sdk
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.6#egg=django-icommons-common

--- a/lti_emailer/requirements/demo.txt
+++ b/lti_emailer/requirements/demo.txt
@@ -5,6 +5,5 @@
  
 # below are requirements specific to the stage environment
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.4#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.4#egg=django-icommons-ui
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.0#egg=django-auth-lti

--- a/lti_emailer/requirements/local.txt
+++ b/lti_emailer/requirements/local.txt
@@ -11,6 +11,5 @@ mock
 pep8
 flake8
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@develop#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@develop#egg=django-icommons-ui
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@develop#egg=django-auth-lti

--- a/lti_emailer/requirements/production.txt
+++ b/lti_emailer/requirements/production.txt
@@ -5,6 +5,5 @@
  
 # below are requirements specific to the production environment
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.4#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.4#egg=django-icommons-ui
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.0#egg=django-auth-lti

--- a/lti_emailer/requirements/qa.txt
+++ b/lti_emailer/requirements/qa.txt
@@ -8,6 +8,5 @@
 oauthlib
 requests-oauthlib
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.4#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.4#egg=django-icommons-ui
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.0#egg=django-auth-lti

--- a/lti_emailer/requirements/test.txt
+++ b/lti_emailer/requirements/test.txt
@@ -8,6 +8,5 @@
 oauthlib
 requests-oauthlib
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@develop#egg=django-icommons-common
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@develop#egg=django-icommons-ui
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@develop#egg=django-auth-lti

--- a/lti_emailer/settings/base.py
+++ b/lti_emailer/settings/base.py
@@ -92,17 +92,7 @@ WSGI_APPLICATION = 'lti_emailer.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
 
-DATABASE_APPS_MAPPING = {
-    'icommons_common': 'termtool',
-    'auth': 'default',
-    'contenttypes': 'default',
-    'sessions': 'default',
-    'mailing_list': 'default'
-}
-
-DATABASE_MIGRATION_WHITELIST = ['default']
-
-DATABASE_ROUTERS = ['icommons_common.routers.DatabaseAppsRouter']
+DATABASE_ROUTERS = ['icommons_common.routers.CourseSchemaDatabaseRouter']
 
 DATABASES = {
     'default': {
@@ -127,6 +117,8 @@ DATABASES = {
     }
 }
 
+COURSE_SCHEMA_DB_NAME = 'termtool'
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
@@ -145,7 +137,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
 
-STATIC_URL = '/lti_emailer/static/'
+STATIC_URL = '/static/'
 
 STATIC_ROOT = os.path.normpath(os.path.join(BASE_DIR, 'http_static'))
 
@@ -240,7 +232,7 @@ LOGGING = {
         'logfile': {
             'level': 'DEBUG',
             'class': 'logging.handlers.WatchedFileHandler',
-            'filename': '/var/opt/tlt/logs/lti_emailer.log',
+            'filename': os.path.join(SECURE_SETTINGS.get('log_root', ''), 'lti_emailer.log'),
             'formatter': 'verbose',
         },
         'console': {
@@ -248,13 +240,6 @@ LOGGING = {
             'class': 'logging.StreamHandler',
             'formatter': 'simple',
         },
-        'request': {
-            'level': 'DEBUG',
-            'class': 'logging.handlers.WatchedFileHandler',
-            'filename': os.path.join(SECURE_SETTINGS.get('log_root', ''), 'lti_emailer.log'),
-            'formatter': 'verbose',
-        },
-
     },
     'loggers': {
         '': {
@@ -263,7 +248,7 @@ LOGGING = {
             'propagate': True,
         },
         'django.request': {
-            'handlers': ['request'],
+            'handlers': ['logfile'],
             'level': 'DEBUG',
             'propagate': False,
         },

--- a/lti_emailer/settings/local.py
+++ b/lti_emailer/settings/local.py
@@ -12,5 +12,4 @@ DEBUG_TOOLBAR_CONFIG = {
     'INTERCEPT_REDIRECTS': False,
 }
 
-LOGGING['handlers']['logfile']['filename'] = 'app.log'
 LOGGING['loggers']['']['level'] = 'DEBUG'

--- a/lti_emailer/settings/unit_test.py
+++ b/lti_emailer/settings/unit_test.py
@@ -1,16 +1,13 @@
-from .local import *
+from .base import *
 
 # Make tests faster
+
+DATABASE_ROUTERS = []
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(os.path.dirname(__file__), 'test.db'),
-        'TEST_NAME': os.path.join(os.path.dirname(__file__), 'test.db'),
-    },
-    'termtool': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(os.path.dirname(__file__), 'test.db'),
-        'TEST_NAME': os.path.join(os.path.dirname(__file__), 'test.db'),
+        'NAME': 'lti_emailer',
     },
 }
 


### PR DESCRIPTION
…ironments and don't use any router for unit tests so that migrations are run during testing.  Update versions of canvas sdk and commons_common used in application.  Move icommons_common requirement into base.  Update static url to not include app name prefix.  Remove request log handler and point to log file handler instead.  Allow Django to append `test_` to database name when running unit tests.

@douglashall 
@rascalking 
@elliottyates 