### PR TITLE
Sprint 25 Use a dummy api key for listserv api tests

### DIFF
--- a/mailgun/tests.py
+++ b/mailgun/tests.py
@@ -5,6 +5,7 @@ import time
 import uuid
 
 from django.conf import settings
+from django.test.utils import override_settings
 from django.test import TestCase
 from django.core.urlresolvers import reverse_lazy
 
@@ -257,6 +258,7 @@ class ListservClientTests(TestCase):
             listserv_client.delete_members(mailing_list, emails)
 
 
+@override_settings(LISTSERV_API_KEY=str(uuid.uuid4()))
 class DecoratorTests(TestCase):
     longMessage = True
 


### PR DESCRIPTION
This is needed to run the unit tests without having to have secure settings configured.