### PR TITLE
prevent mixed content issues with mailto links

### DIFF
--- a/mailing_list/templates/mailing_list/_mailing_list_details.html
+++ b/mailing_list/templates/mailing_list/_mailing_list_details.html
@@ -24,6 +24,7 @@
 <div class="float-left col-50 info-btn-status">
 {% verbatim %}
   <a id="email-section-{{ list.section_id }}"
+     target="_top"
      href="mailto:{{ list.address }}"
 {% endverbatim %}
      class="btn"


### PR DESCRIPTION
Prevent mixed content warnings and mailto handler redirect failures due to iframe. Logged as bug TLT-1843, apologies for the branch name confusion.