### PR TITLE
Feature/listerv detail view based on front end cleanup

### DIFF
--- a/mailing_list/templates/mailing_list/_mailing_list_details.html
+++ b/mailing_list/templates/mailing_list/_mailing_list_details.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 <div class="float-left col-50">
-  <p>
+  <p class="no-margin">
     <strong>
       <span ng-bind="list.name"></span>
       (<ng-pluralize
@@ -40,8 +40,7 @@
     Email <span ng-bind="list.name"></span>
   </a>
   <p>
-    <span ng-bind="ml.accessLevelStatus[list.access_level]['{{ scope }}']"></span>
-    <br>
+    <span ng-bind="ml.accessLevelStatus[list.access_level]['{{ scope }}']"></span> 
     <a href="#"
        data-toggle="modal"
 {% verbatim %}

--- a/mailing_list/templates/mailing_list/_mailing_list_members_by_name.html
+++ b/mailing_list/templates/mailing_list/_mailing_list_members_by_name.html
@@ -3,9 +3,9 @@
 {% with letter_ranges="A-D,E-H,I-L,M-P,Q-S,T-Z" %}
 {% regroup enrollments by user.sortable_name|to_letter_range:letter_ranges as enrollments_by_name %}
 <li class="list-group-item pagination-lti">
-    <span class="pagination-lti-label pagination-lti-view">View: </span>
+    <span class="float-left pagination-lti-label pagination-lti-view">View: </span>
     {% with name_buckets=enrollments_by_name|list_comp:'grouper' %}
-    <ul class="nav nav-pills nav-section-pagination">
+    <ul class="float-left list-alphabet nav-section-pagination">
         <li class="active"><a class="viewAll" href="#">All</a></li>
         <li class="{% if 'A-D' not in name_buckets %} disabled {% endif %}"><a class="a-d" href="#">A - D</a></li>
         <li class="{% if 'E-H' not in name_buckets %} disabled {% endif %}"><a class="e-h" href="#">E - H</a></li>
@@ -15,19 +15,19 @@
         <li class="{% if 'T-Z' not in name_buckets %} disabled {% endif %}"><a class="t-z" href="#">T - Z</a></li>
     </ul>
     {% endwith %}
-    <span class="pagination-lti-label pagination-lti-range">{{ enrollments|first|enrollment_lname }} - {{ enrollments|last|enrollment_lname }}</span>
+    <span class="float-right pagination-lti-label pagination-lti-range">{{ enrollments|first|enrollment_lname }} - {{ enrollments|last|enrollment_lname }}</span>
 </li>
 {% for enrollment_by_name in enrollments_by_name %}
     {% for enrollee in enrollment_by_name.list %} 
         <li class="list-group-item list-student {{ enrollment_by_name.grouper|lower }}">
-            <span class="studentRole">{{enrollee.role|get_enroll_type_display}}</span>
-            <span class="studentName">{{enrollee.user.name}}</span> 
-            <span class="label label-{{enrollee.badge_label_name|lower}}">{{enrollee.badge_label_name|upper}}</span>
-            <span>
-              <a href="mailto:{{ enrollee.email_address }}" target="_top">
-                {{ enrollee.email_address }}
-              </a>
-            </span>
+            
+            <span class="float-left">
+                {{enrollee.user.name}} <br>
+                <a href="mailto:{{ enrollee.email_address }}" target="_top">
+                    {{ enrollee.email_address }}
+                </a>
+            </span> 
+            <span class="float-right">{{enrollee.role|get_enroll_type_display}}</span>
         </li>
     {% endfor %}
 {% endfor %}

--- a/mailing_list/templates/mailing_list/admin_index.html
+++ b/mailing_list/templates/mailing_list/admin_index.html
@@ -15,27 +15,35 @@
     <img src="{% static 'images/ajax-loader-large.gif' %}"/>
   </div>
   <main class="ng-hide" ng-show="ml.loaded">
-    <div id="course-sections" ng-show="ml.hasPrimarySections()">
+    <div id="main-section" ng-show="ml.hasPrimarySections()">
       <div ng-repeat="list in ml.primarySectionLists">
         {% verbatim %}
-        <p class="caption-primary" ng-show="$first">
-          <a class="partial-underline" href="{{ ml.listMembersUrl(list) }}">
-            <span class="link-text">
-              View course members' email addresses</span>
+        <h2 class="all-members" ng-show="$first">
+          <a class="semi-underline" href="{{ ml.listMembersUrl(list) }}">
+            <span>
+              View course members' email addresses
+            </span>
             ({{ list.members_count }} members)
+            
           </a>
-        </p>
-        <h3>
-          {{ ml.primarySectionLists[0].name }} mailing list address
-        </h3>
-        <p class="caption-secondary">
-          The mailing list contains teaching staff, students, and others
-          who have been added to this course.
-        </p>
-        {% endverbatim %}
-        <div class="content-section">
-          {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
+        </h2>
+        
+        <div class="main-section-content">
+          <h2>
+            {{ ml.primarySectionLists[0].name }} mailing list address
+          </h2>
+          <div class="listerv-content">
+            <p class="caption-secondary">
+              The mailing list contains teaching staff, students, and others
+              who have been added to this course.
+            </p>
+            {% endverbatim %}
+            <div class="content-section">
+              {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
+            </div>
+          </div>
         </div>
+
       </div>
     </div>
     <div id="course-sections" ng-show="!ml.hasPrimarySections()">
@@ -46,18 +54,20 @@
     </div>
 
     <div ng-show="ml.hasOtherSections()">
-      <h3>
+      <h2>
         {% verbatim %}{{ ml.primarySectionLists[0].name }}{% endverbatim %}
         sections mailing list addresses
-      </h3>
-      <p class="caption-secondary">
-        These sections are created in the Manage Sections tool (if installed
-        in your account) or are being sent from the Registrar's Office.
-        Any changes made to those sections will be reflected within these lists.
-      </p>
-      <div id="course-sections">
-        <div ng-repeat="list in ml.otherSectionLists" class="content-section">
-          {% include "mailing_list/_mailing_list_details.html" with scope="section" %}
+      </h2>
+      <div class="listerv-content">
+        <p class="caption-secondary">
+          These sections are created in the Manage Sections tool (if installed
+          in your account) or are being sent from the Registrar's Office.
+          Any changes made to those sections will be reflected within these lists.
+        </p>
+        <div id="course-sections">
+          <div ng-repeat="list in ml.otherSectionLists" class="content-section">
+            {% include "mailing_list/_mailing_list_details.html" with scope="section" %}
+          </div>
         </div>
       </div>
     </div>

--- a/mailing_list/templates/mailing_list/base_list_details.html
+++ b/mailing_list/templates/mailing_list/base_list_details.html
@@ -14,7 +14,7 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="{% static 'favicon.ico' %}" rel="icon" type="image/x-icon">
-    <link rel="stylesheet" type="text/css" href="{% static "harvard-bootstrap/css/harvard-bootstrap.css" %}" media="screen"/>
+    <link rel="stylesheet" type="text/css" href="{% static 'lti-css/listserv.css' %}" media="screen"/>
     {% block css %}{% endblock css %}
     <script src="{% static 'jquery-1.10.2/jquery-1.10.2.min.js' %}"></script>
     <script src="{% static "bootstrap-3.0.3/dist/js/bootstrap.min.js" %}"></script>

--- a/mailing_list/templates/mailing_list/list_details.html
+++ b/mailing_list/templates/mailing_list/list_details.html
@@ -22,7 +22,7 @@
     <main>
     <div class="row row-lti col-md-8 lti-section">
       {% if enrollments %}
-      <ul id="people-list" class="list-group list-section">
+      <ul id="people-list" class="list-with-floats">
         {% include "mailing_list/_mailing_list_members_by_name.html" %}
       </ul>
       {% else %}


### PR DESCRIPTION
This PR starts to fix the detail view of the listserv to match manage sections without bootstrap dependencies.

This code was based of the code that is been reviewed in PR #43 