### PR TITLE
Sprint 29 TLT-1880 From address needs to be the mailing list address for maximum deliverability.

### DIFF
--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -206,14 +206,14 @@ class MailgunClient(object):
                     len(emails)
                 ))
 
-    def send_mail(self, from_address, to_address, mailing_list_address,  subject='', text='', html=''):
+    def send_mail(self, from_address, reply_to_address, to_address, cc_address, subject='', text='', html=''):
         api_url = "%s%s/messages" % (settings.LISTSERV_API_URL, settings.LISTSERV_DOMAIN)
         payload = {
             'from': from_address,
+            'sender': from_address,
+            'h:Reply-To': reply_to_address,
             'to': to_address,
-            'h:cc': mailing_list_address,
-            'sender': mailing_list_address,
-            'h:Reply-To': from_address,
+            'h:cc': cc_address,
             'subject': subject,
             'text': text,
             'html': html

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -93,8 +93,7 @@ def handle_mailing_list_email_route(request):
             'message_body': message_body
         }))
         subject = "Undeliverable mail"
-        ml.send_mail(ml.address, sender_address.full_spec(),
-                     subject, html=content)
+        ml.send_mail('', ml.address, sender_address.full_spec(), subject, html=content)
     else:
         # try to prepend [SHORT TITLE] to subject, keep going if lookup fails
         try:
@@ -159,7 +158,8 @@ def handle_mailing_list_email_route(request):
                     member_address, sender_address.full_spec(), subject
                 )
             )
-            ml.send_mail(sender_address.full_spec(), member_address, subject,
-                         text=message_body)
+            ml.send_mail(
+                sender_address.display_name, sender_address.address, member_address, subject, text=message_body
+            )
 
     return JsonResponse({'success': True})

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -93,7 +93,7 @@ def handle_mailing_list_email_route(request):
             'message_body': message_body
         }))
         subject = "Undeliverable mail"
-        ml.send_mail('', ml.address, sender_address.full_spec(), subject, html=content)
+        ml.send_mail('', ml.address, sender_address.address, subject, html=content)
     else:
         # try to prepend [SHORT TITLE] to subject, keep going if lookup fails
         try:

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -3,6 +3,8 @@ import json
 
 from datetime import datetime
 
+from flanker import addresslib
+
 from django.conf import settings
 from django.db import models
 from django.core.cache import cache
@@ -152,10 +154,14 @@ class MailingList(models.Model):
     def teaching_staff_addresses(self):
         return self._get_enrolled_teaching_staff_email_set()
 
-    def send_mail(self, sender_address, to_address, subject='', text='', html=''):
+    def send_mail(self, sender_display_name, sender_address, to_address, subject='', text='', html=''):
         logger.debug("in send_mail: sender_address=%s, to_address=%s, mailing_list.address=%s "
                      % (sender_address, to_address, self.address))
-        listserv_client.send_mail(sender_address, to_address,  self.address, subject, text, html)
+        mailing_list_address = addresslib.address.parse(self.address)
+        mailing_list_address.display_name = sender_display_name
+        listserv_client.send_mail(
+            mailing_list_address.full_spec(), sender_address, to_address, self.address, subject, text, html
+        )
 
     def sync_listserv_membership(self):
         """


### PR DESCRIPTION
Populate Reply-To header with original sender for single replies.