### PR TITLE
HOTFIX v1.2.1 Fixes Canvas permission lookup

### DIFF
--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -10,6 +10,6 @@ django-angular==0.7.13
 huey==0.4.8
 flanker==0.4.34
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.7.9#egg=canvas-python-sdk==0.7.9
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.19#egg=django-icommons-common==1.9.19
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.20#egg=django-icommons-common==1.9.20
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.2#egg=django-auth-lti==1.2.2

--- a/lti_emailer/settings/demo.py
+++ b/lti_emailer/settings/demo.py
@@ -1,1 +1,4 @@
 from .aws import *
+
+# Allow the mailing_list app to allow any user to be added to listserv
+IGNORE_WHITELIST = True

--- a/lti_emailer/settings/production.py
+++ b/lti_emailer/settings/production.py
@@ -1,1 +1,4 @@
 from .aws import *
+
+# Allow the mailing_list app to allow any user to be added to listserv
+IGNORE_WHITELIST = True


### PR DESCRIPTION
The fix is actually in django-icommons-common. This just increments the package version.

https://github.com/Harvard-University-iCommons/django-icommons-common/pull/102