### PR TITLE
Sprint 29 TLT-1892 Mailing list should forward attachments

### DIFF
--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -206,8 +206,10 @@ class MailgunClient(object):
                     len(emails)
                 ))
 
-    def send_mail(self, from_address, reply_to_address, to_address, cc_address, subject='', text='', html=''):
-        api_url = "%s%s/messages" % (settings.LISTSERV_API_URL, settings.LISTSERV_DOMAIN)
+    def send_mail(self, from_address, reply_to_address, to_address, cc_address,
+                  subject='', text='', html='', attachments=None):
+        api_url = "%s%s/messages" % (settings.LISTSERV_API_URL,
+                                     settings.LISTSERV_DOMAIN)
         payload = {
             'from': from_address,
             'sender': from_address,
@@ -219,8 +221,15 @@ class MailgunClient(object):
             'html': html
         }
 
+        if attachments:
+            files = tuple(('attachment', (f.name, f, f.content_type))
+                               for f in attachments)
+        else:
+            files = None
+
         with ApiRequestTimer(logger, 'POST', api_url, payload) as timer:
-            response = requests.post(api_url, auth=(self.api_user, self.api_key), data=payload)
+            response = requests.post(api_url, auth=(self.api_user, self.api_key),
+                                     data=payload, files=files)
             timer.status_code = response.status_code
 
         if response.status_code != 200:

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -226,12 +226,11 @@ class MailgunClient(object):
             files.extend([('attachment', (f.name, f, f.content_type))
                               for f in attachments])
         if inlines:
-            header = {
-                'Content-Disposition': 'inline; filename={}; size={}'.format(
-                                           f.name, f.size),
-            }
-            files.extend([('inline', (f.name, f, f.content_type, header))
-                              for f in inlines])
+            for f in inlines:
+                disposition = 'inline; filename={}; size={}'.format(
+                                  f.name, f.size)
+                files.append(('inline', (f.name, f, f.content_type,
+                                         {'Content-Disposition': disposition})))
 
         with ApiRequestTimer(logger, 'POST', api_url, payload) as timer:
             response = requests.post(api_url, auth=(self.api_user, self.api_key),

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -207,7 +207,7 @@ class MailgunClient(object):
                 ))
 
     def send_mail(self, from_address, reply_to_address, to_address, cc_address,
-                  subject='', text='', html='', attachments=None):
+                  subject='', text='', html='', attachments=None, inlines=None):
         api_url = "%s%s/messages" % (settings.LISTSERV_API_URL,
                                      settings.LISTSERV_DOMAIN)
         payload = {
@@ -221,11 +221,13 @@ class MailgunClient(object):
             'html': html
         }
 
+        files = []
         if attachments:
-            files = [('attachment', (f.name, f, f.content_type))
-                         for f in attachments]
-        else:
-            files = None
+            files.extend([('attachment', (f.name, f, f.content_type))
+                              for f in attachments])
+        if inlines:
+            files.extend([('inline', (f.name, f, f.content_type))
+                              for f in inlines])
 
         with ApiRequestTimer(logger, 'POST', api_url, payload) as timer:
             response = requests.post(api_url, auth=(self.api_user, self.api_key),

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -222,8 +222,8 @@ class MailgunClient(object):
         }
 
         if attachments:
-            files = tuple(('attachment', (f.name, f, f.content_type))
-                               for f in attachments)
+            files = [('attachment', (f.name, f, f.content_type))
+                         for f in attachments]
         else:
             files = None
 

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -226,9 +226,8 @@ class MailgunClient(object):
             files.extend([('attachment', (f.name, f, f.content_type))
                               for f in attachments])
         if inlines:
-            for f in inlines:
-                files.append(('inline', (f.name, f, f.content_type,
-                                         {'Content-ID': f.cid})))
+            files.extend([('inline', (f.name, f, f.content_type))
+                              for f in inlines])
 
         with ApiRequestTimer(logger, 'POST', api_url, payload) as timer:
             response = requests.post(api_url, auth=(self.api_user, self.api_key),

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -226,7 +226,11 @@ class MailgunClient(object):
             files.extend([('attachment', (f.name, f, f.content_type))
                               for f in attachments])
         if inlines:
-            files.extend([('inline', (f.name, f, f.content_type))
+            header = {
+                'Content-Disposition': 'inline; filename={}; size={}'.format(
+                                           f.name, f.size),
+            }
+            files.extend([('inline', (f.name, f, f.content_type, header))
                               for f in inlines])
 
         with ApiRequestTimer(logger, 'POST', api_url, payload) as timer:

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -227,10 +227,8 @@ class MailgunClient(object):
                               for f in attachments])
         if inlines:
             for f in inlines:
-                disposition = 'inline; filename={}; size={}'.format(
-                                  f.name, f.size)
                 files.append(('inline', (f.name, f, f.content_type,
-                                         {'Content-Disposition': disposition})))
+                                         {'Content-ID': f.cid})))
 
         with ApiRequestTimer(logger, 'POST', api_url, payload) as timer:
             response = requests.post(api_url, auth=(self.api_user, self.api_key),

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -195,7 +195,8 @@ def _get_attachments_inlines(request):
         logger.exception('Unable to find content-id map in this email, '
                          'forwarding all files as attachments.')
         content_id_map = {}
-    attachment_name_to_cid = {v: k for k,v in content_id_map.iteritems()}
+    attachment_name_to_cid = {v: k.strip('<>')
+                                  for k,v in content_id_map.iteritems()}
 
     for n in xrange(1, attachment_count+1):
         attachment_name = 'attachment-{}'.format(n)

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -38,6 +38,9 @@ def handle_mailing_list_email_route(request):
     body_plain = request.POST.get('body-plain')
     body_html = request.POST.get('body-html')
     in_reply_to = request.POST.get('In-Reply-To')
+    attachment_count = request.POST.get('attachment-count', 0)
+    attachments = [request.FILES['attachment-{}'.format(n)]
+                       for n in xrange(attachment_count)]
 
     logger.info("Handling Mailgun mailing list email from %s to %s", sender, recipient)
     logger.debug('Full mailgun post: {}'.format(request.POST))
@@ -161,7 +164,8 @@ def handle_mailing_list_email_route(request):
             )
             ml.send_mail(
                 sender_address.display_name, sender_address.address,
-                member_address, subject, text=body_plain, html=body_html
+                member_address, subject, text=body_plain, html=body_html,
+                attachments=attachments
             )
 
     return JsonResponse({'success': True})

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -159,6 +159,7 @@ def handle_mailing_list_email_route(request):
         # mailgun won't let us specify the cid on post
         if inlines:
             for f in inlines:
+                logger.debug('Replacing "{}" with "{}" in body'.format(f.cid, f.name))
                 body_html = re.sub(f.cid, f.name, body_html)
 
         # and send it off
@@ -197,6 +198,7 @@ def _get_attachments_inlines(request):
         content_id_map = {}
     attachment_name_to_cid = {v: k.strip('<>')
                                   for k,v in content_id_map.iteritems()}
+    logger.debug('Attachment name to cid: {}'.format(attachment_name_to_cid))
 
     for n in xrange(1, attachment_count+1):
         attachment_name = 'attachment-{}'.format(n)

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -188,12 +188,14 @@ def _get_attachments_inlines(request):
         logger.exception('Unable to find content-id map in this email, '
                          'forwarding all files as attachments.')
         content_id_map = {}
-    inline_attachment_names = content_id_map.values()
+    attachment_name_to_cid = {v: k.strip('<>')
+                                  for k,v in content_id_map.iteritems()}
 
     for n in xrange(1, attachment_count):
         attachment_name = 'attachment-{}'.format(n)
         file_ = request.FILES[attachment_name]
-        if attachment_name in inline_attachment_names:
+        if attachment_name in attachment_name_to_cid:
+            file_.cid = attachment_name_to_cid[attachment_name]
             inlines.append(file_)
         else:
             attachments.append(file_)

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -38,7 +38,12 @@ def handle_mailing_list_email_route(request):
     body_plain = request.POST.get('body-plain')
     body_html = request.POST.get('body-html')
     in_reply_to = request.POST.get('In-Reply-To')
-    attachment_count = request.POST.get('attachment-count', 0)
+    try:
+        attachment_count = int(request.POST.get('attachment-count', 0))
+    except RuntimeError:
+        logger.exception('Unable to determine if there were attachments to '
+                         'this email')
+        attachment_count = 0
     attachments = [request.FILES['attachment-{}'.format(n)]
                        for n in xrange(attachment_count)]
 

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -47,6 +47,13 @@ def handle_mailing_list_email_route(request):
     attachments = [request.FILES['attachment-{}'.format(n)]
                        for n in xrange(1, attachment_count+1)]
 
+    # TEST TEST TEST
+    for n in xrange(1, attachment_count+1):
+        f = request.FILES['attachment-{}'.format(n)]
+        logger.debug(
+            'Attachment {}: name={}, size={}, content_type={}, content_type_extra={}'
+                .format(n, f.name, f.size, f.content_type, f.content_type_extra))
+
     logger.info("Handling Mailgun mailing list email from %s to %s", sender, recipient)
     logger.debug('Full mailgun post: {}'.format(request.POST))
 

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -160,6 +160,7 @@ def handle_mailing_list_email_route(request):
         if inlines:
             for f in inlines:
                 logger.debug('Replacing "{}" with "{}" in body'.format(f.cid, f.name))
+                body_plain = re.sub(f.cid, f.name, body_plain)
                 body_html = re.sub(f.cid, f.name, body_html)
 
         # and send it off

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from django.http import JsonResponse

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -45,7 +45,7 @@ def handle_mailing_list_email_route(request):
                          'this email')
         attachment_count = 0
     attachments = [request.FILES['attachment-{}'.format(n)]
-                       for n in xrange(attachment_count)]
+                       for n in xrange(1, attachment_count+1)]
 
     logger.info("Handling Mailgun mailing list email from %s to %s", sender, recipient)
     logger.debug('Full mailgun post: {}'.format(request.POST))

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -206,6 +206,7 @@ def _get_attachments_inlines(request):
         file_ = request.FILES[attachment_name]
         if attachment_name in attachment_name_to_cid:
             file_.cid = attachment_name_to_cid[attachment_name]
+            file_.name = file_.name.replace(' ', '_')
             inlines.append(file_)
         else:
             attachments.append(file_)

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -188,8 +188,7 @@ def _get_attachments_inlines(request):
         logger.exception('Unable to find content-id map in this email, '
                          'forwarding all files as attachments.')
         content_id_map = {}
-    attachment_name_to_cid = {v: k.strip('<>')
-                                  for k,v in content_id_map.iteritems()}
+    attachment_name_to_cid = {v: k for k,v in content_id_map.iteritems()}
 
     for n in xrange(1, attachment_count):
         attachment_name = 'attachment-{}'.format(n)

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -155,7 +155,7 @@ class MailingList(models.Model):
         return self._get_enrolled_teaching_staff_email_set()
 
     def send_mail(self, sender_display_name, sender_address, to_address,
-                  subject='', text='', html='', attachments=None):
+                  subject='', text='', html='', attachments=None, inlines=None):
         logger.debug("in send_mail: sender_address=%s, to_address=%s, "
                      "mailing_list.address=%s ",
                      sender_address, to_address, self.address)
@@ -163,7 +163,7 @@ class MailingList(models.Model):
         mailing_list_address.display_name = sender_display_name
         listserv_client.send_mail(
             mailing_list_address.full_spec(), sender_address, to_address,
-            self.address, subject, text, html, attachments
+            self.address, subject, text, html, attachments, inlines
         )
 
     def sync_listserv_membership(self):

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -154,13 +154,16 @@ class MailingList(models.Model):
     def teaching_staff_addresses(self):
         return self._get_enrolled_teaching_staff_email_set()
 
-    def send_mail(self, sender_display_name, sender_address, to_address, subject='', text='', html=''):
-        logger.debug("in send_mail: sender_address=%s, to_address=%s, mailing_list.address=%s "
-                     % (sender_address, to_address, self.address))
+    def send_mail(self, sender_display_name, sender_address, to_address,
+                  subject='', text='', html='', attachments=None):
+        logger.debug("in send_mail: sender_address=%s, to_address=%s, "
+                     "mailing_list.address=%s ",
+                     sender_address, to_address, self.address)
         mailing_list_address = addresslib.address.parse(self.address)
         mailing_list_address.display_name = sender_display_name
         listserv_client.send_mail(
-            mailing_list_address.full_spec(), sender_address, to_address, self.address, subject, text, html
+            mailing_list_address.full_spec(), sender_address, to_address,
+            self.address, subject, text, html, attachments
         )
 
     def sync_listserv_membership(self):


### PR DESCRIPTION
This is basically 2 changes:
* look for attachments in the router, and use the content-id-map header to figure out which ones are attachments and which are inline
* replace the content-id for inlined images in the plaintext/html body with the content-id we know mailgun will assign on post (they won't let us just specify the original content-it).