### PR TITLE
Sprint 29 TLT-1896 Use mailgun batch send

### DIFF
--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -206,20 +206,23 @@ class MailgunClient(object):
                     len(emails)
                 ))
 
-    def send_mail(self, from_address, reply_to_address, to_address, cc_address,
-                  subject='', text='', html='', attachments=None, inlines=None):
+    def send_mail(self, list_address, from_address, to_address, subject='',
+                  text='', html='', original_to_address=None,
+                  original_cc_address=None, attachments=None, inlines=None):
         api_url = "%s%s/messages" % (settings.LISTSERV_API_URL,
                                      settings.LISTSERV_DOMAIN)
         payload = {
-            'from': from_address,
-            'sender': from_address,
-            'h:Reply-To': reply_to_address,
+            'from': list_address,
+            'h:Reply-To': from_address,
             'to': to_address,
-            'h:cc': cc_address,
             'subject': subject,
             'text': text,
             'html': html
         }
+        if original_to_address:
+            payload['h:To'] = original_to_address
+        if original_cc_address:
+            payload['h:Cc'] = original_cc_address
 
         # we accept a single address or a list of addresses in to_address.
         # if it's a list, add in recipient_variables to make sure mailgun

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -213,11 +213,12 @@ class MailgunClient(object):
                                      settings.LISTSERV_DOMAIN)
         payload = {
             'from': list_address,
+            'h:List-Id': '<{}>'.format(list_address),
             'h:Reply-To': from_address,
-            'to': to_address,
+            'html': html,
             'subject': subject,
             'text': text,
-            'html': html
+            'to': to_address,
         }
         if original_to_address:
             payload['h:To'] = original_to_address

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -220,6 +220,14 @@ class MailgunClient(object):
             'text': text,
             'to': to_address,
         }
+
+        # we want the to/cc fields as received by list users to be as close
+        # as possible to the same as those that were sent by the sender.
+        # mailgun will always add the individual recipient to the To field,
+        # but we can at least ensure that's the only change.
+        #
+        # these are prefixed with h: so that mailgun doesn't think we want it
+        # to send copies to these addresses as well.
         if original_to_address:
             payload['h:To'] = original_to_address
         if original_cc_address:

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -227,7 +227,7 @@ class MailgunClient(object):
         #   https://documentation.mailgun.com/user_manual.html#batch-sending
         if not isinstance(to_address, basestring):
             recipient_variables = {e: {} for e in to_address}
-            payload['recipient_variabls'] = json.dumps(recipient_variables)
+            payload['recipient_variables'] = json.dumps(recipient_variables)
 
         files = []
         if attachments:

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -221,6 +221,14 @@ class MailgunClient(object):
             'html': html
         }
 
+        # we accept a single address or a list of addresses in to_address.
+        # if it's a list, add in recipient_variables to make sure mailgun
+        # doesn't include the whole list in the to: field, per
+        #   https://documentation.mailgun.com/user_manual.html#batch-sending
+        if not isinstance(to_address, basestring):
+            recipient_variables = {e: {} for e in to_address}
+            payload['recipient_variabls'] = json.dumps(recipient_variables)
+
         files = []
         if attachments:
             files.extend([('attachment', (f.name, f, f.content_type))

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -227,7 +227,7 @@ class MailgunClient(object):
         #   https://documentation.mailgun.com/user_manual.html#batch-sending
         if not isinstance(to_address, basestring):
             recipient_variables = {e: {} for e in to_address}
-            payload['recipient_variables'] = json.dumps(recipient_variables)
+            payload['recipient-variables'] = json.dumps(recipient_variables)
 
         files = []
         if attachments:

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -176,7 +176,7 @@ def handle_mailing_list_email_route(request):
         )
         ml.send_mail(
             sender_address.display_name, sender_address.address,
-            member_addresses, subject, text=body_plain, html=body_html,
+            list(member_addresses), subject, text=body_plain, html=body_html,
             attachments=attachments, inlines=inlines
         )
 

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -124,6 +124,8 @@ def handle_mailing_list_email_route(request):
         # recipients.
         logger.debug('Full list of recipients: {}'.format(member_addresses))
         try:
+            logger.debug('Removing sender {} from the list of recipients'.format(
+                         sender_address.address))
             member_addresses.remove(sender_address.address)
         except KeyError:
             logger.info("Email sent to mailing list %s from non-member address %s",

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -155,7 +155,8 @@ class MailingList(models.Model):
         return self._get_enrolled_teaching_staff_email_set()
 
     def send_mail(self, sender_display_name, sender_address, to_address,
-                  subject='', text='', html='', attachments=None, inlines=None):
+                  subject='', text='', html='', original_to_address=None,
+                  original_cc_address=None, attachments=None, inlines=None):
         logger.debug("in send_mail: sender_address=%s, to_address=%s, "
                      "mailing_list.address=%s ",
                      sender_address, to_address, self.address)
@@ -163,7 +164,8 @@ class MailingList(models.Model):
         mailing_list_address.display_name = sender_display_name
         listserv_client.send_mail(
             mailing_list_address.full_spec(), sender_address, to_address,
-            self.address, subject, text, html, attachments, inlines
+            subject, text, html, original_to_address, original_cc_address,
+            attachments, inlines
         )
 
     def sync_listserv_membership(self):


### PR DESCRIPTION
This saves us bandwidth, avoids annoying mailgun when we post the same email with 20MB of attachments 300 times, and in spot testing resolves the "attachment is there but empty" problem we'd been seeing with the "one post per recipient" approach.