### PR TITLE
Sprint 29 TLT-1905 Add management command to activate mailing lists for account/term

### DIFF
--- a/lti_emailer/canvas_api_client.py
+++ b/lti_emailer/canvas_api_client.py
@@ -9,7 +9,7 @@ import json
 from django.conf import settings
 from django.core.cache import cache
 
-from canvas_sdk.methods import enrollments, sections, courses
+from canvas_sdk.methods import accounts, courses, enrollments, sections
 from canvas_sdk.utils import get_all_list_data
 from canvas_sdk.exceptions import CanvasAPIError
 
@@ -25,6 +25,26 @@ logger = logging.getLogger(__name__)
 SDK_CONTEXT = SessionInactivityExpirationRC(**settings.CANVAS_SDK_SETTINGS)
 TEACHING_STAFF_ENROLLMENT_TYPES = ['TeacherEnrollment', 'TaEnrollment', 'DesignerEnrollment']
 USER_ATTRIBUTES_TO_COPY = [u'email', u'name', u'sortable_name']
+
+
+def get_courses_for_account_in_term(account_id, enrollment_term_id,
+                                    include_sections=False):
+    kwargs = {
+        'account_id': account_id,
+        'enrollment_term_id': enrollment_term_id,
+    }
+    if include_sections:
+        kwargs['include'] = 'sections'
+
+    try:
+        result = get_all_list_data(
+                     SDK_CONTEXT, accounts.list_active_courses_in_account,
+                     **kwargs)
+    except CanvasAPIError:
+        logger.error('Unable to get courses for account {}, term {}'.format(
+                         account_id, enrollment_term_id))
+        raise
+    return result
 
 
 def get_enrollments(canvas_course_id, section_id):

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -9,7 +9,7 @@ django-cached-authentication-middleware==0.2.1
 django-angular==0.7.13
 huey==0.4.8
 flanker==0.4.34
-git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.7.9#egg=canvas-python-sdk==0.7.9
+git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.8.1#egg=canvas-python-sdk==0.8.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.9.20#egg=django-icommons-common==1.9.20
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.2#egg=django-auth-lti==1.2.2

--- a/mailing_list/management/commands/activate_all_lists.py
+++ b/mailing_list/management/commands/activate_all_lists.py
@@ -1,0 +1,73 @@
+import argparse
+import csv
+import logging
+import operator
+
+from django.core.management.base import BaseCommand, CommandError
+
+from lti_emailer.canvas_api_client import get_courses_for_account_in_term
+from mailing_list.models import MailingList
+
+
+OUTPUT_FIELDS = ['id', 'sis_course_id', 'name', 'course_code']
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = 'Activates all mailing lists for a given account and enrollment term'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--account-id', type=int, required=True,
+                            help='Canvas account id')
+        parser.add_argument('--enrollment-term-id', type=int, required=True,
+                            help='Canvas enrollment term id')
+        parser.add_argument('--output-file', type=argparse.FileType('w'),
+                            help='File to output mailing list details to')
+
+    def handle(self, *args, **options):
+        try:
+            courses = get_courses_for_account_in_term(
+                          options['account_id'], options['enrollment_term_id'])
+        except RuntimeError as e:
+            raise CommandError(str(e))
+
+        course_lists = {}
+        failures = {}
+        defaults = {'access_level': MailingList.ACCESS_LEVEL_MEMBERS}
+        for course in courses:
+            try:
+                lists = MailingList.objects.\
+                            get_or_create_mailing_lists_for_canvas_course_id(
+                                    course['id'], defaults=defaults)
+            except RuntimeError as e:
+                failures[course['id']] = str(e)
+                continue
+            course_lists[course['id']] = [ml for ml in lists
+                                              if ml['is_primary_section']]
+
+        if failures:
+            for course_id, error_message in failures.iteritems():
+                logger.error(
+                    'Unable to get/create mailing lists for canvas course id '
+                    '{}: {}'.format(course_id, error_message))
+            self.stderr.write(
+                'Failed to get/create lists for {} courses'.format(
+                    len(failures)))
+
+        num_lists = reduce(operator.add, map(len, course_lists.values()), 0)
+        self.stdout.write('Total of {} list(s) for {} course(s)'.format(
+                              num_lists, len(courses)))
+
+        if options.get('output_file'):
+            courses_by_id = {c['id']: c for c in courses}
+            writer = csv.writer(options['output_file'])
+            writer.writerow(('canvas_course_id', 'sis_course_id', 'course_name',
+                             'course_code', 'course_lists'))
+            for course_id in sorted(course_lists):
+                course = courses_by_id[course_id]
+                lists = course_lists[course_id]
+                row = (course_id, course['sis_course_id'], course['name'],
+                       course['course_code'],
+                       ';'.join([l['address'] for l in lists]))
+                writer.writerow(row)

--- a/mailing_list/management/commands/sync_listserv.py
+++ b/mailing_list/management/commands/sync_listserv.py
@@ -1,9 +1,7 @@
 import logging
 
-from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
-from mailing_list.models import MailingList
 from mailing_list.tasks import course_sync_listserv
 
 
@@ -12,9 +10,6 @@ logger = logging.getLogger(__name__)
 
 class Command(BaseCommand):
     help = 'Synchronizes mailing lists created for canvas courses with the enrollment list for each course'
-
-    def __init__(self, *args, **kwargs):
-        super(Command, self).__init__(*args, **kwargs)
 
     def handle(self, *args, **options):
         logger.info("Beginning sync_listserv job for canvas_course_ids %s", args)


### PR DESCRIPTION
(depends on https://github.com/penzance/canvas_python_sdk/pull/59)

The expectation is that a school will request that we make sure that their mailing lists are created and ready to be used in the run up to the beginning of a term.  A BA will look up the Canvas account id and enrollment term id, and request that devops run this command with those ids.  Devops will verify that it completed successfully, and return the output csv to the BA, who will pass it along to the school.

Usage:
```
$ python manage.py activate_all_lists --help
usage: manage.py activate_all_lists [-h] [--version] [-v {0,1,2,3}]
                                    [--settings SETTINGS]
                                    [--pythonpath PYTHONPATH] [--traceback]
                                    [--no-color] --account-id ACCOUNT_ID
                                    --enrollment-term-id ENROLLMENT_TERM_ID
                                    [--output-file OUTPUT_FILE]

Activates all mailing lists for a given account and enrollment term

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output,
                        2=verbose output, 3=very verbose output
  --settings SETTINGS   The Python path to a settings module, e.g.
                        "myproject.settings.main". If this isn't provided, the
                        DJANGO_SETTINGS_MODULE environment variable will be
                        used.
  --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g.
                        "/home/djangoprojects/myproject".
  --traceback           Raise on CommandError exceptions
  --no-color            Don't colorize the command output.
  --account-id ACCOUNT_ID
                        Canvas account id
  --enrollment-term-id ENROLLMENT_TERM_ID
                        Canvas enrollment term id
  --output-file OUTPUT_FILE
                        File to output mailing list details to
```

Sample command output (after potentially a bunch of debug logging scrolls by):
```
Total of 3 list(s) for 4 course(s)
```

Sample format of output csv file (the first course has no sections, thus no lists):
```
canvas_course_id,sis_course_id,course_name,course_code,primary_section_lists,secondary_section_lists
6248,338227,"GoodWork in Education: When Excellence, Engagement, and Ethics Meet",H175,,
6387,338352,Ed.L.D. Second-Year Core Seminar,L200A,canvas-6387-1667@mg.dev.tlt.harvard.edu,
6842,338224,Education Sector Nonprofits,A019,canvas-6842-2152@mg.dev.tlt.harvard.edu,
6990,338231,Managing Financial Resources in Nonprofit Organizations,A027A,canvas-6990-2301@mg.dev.tlt.harvard.edu,
```