### PR TITLE
Make sure all email address comparisons are lowercased

### DIFF
--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -140,7 +140,9 @@ class MailgunClient(object):
                 raise ListservApiError("Failed to get mailing list members %s range [%d-%d]" % (address, start, end))
             else:
                 data = response.json()
-                result += data['items']
+                for m in data['items']:
+                    m['address'] = m['address'].lower()
+                    result.append(m)
                 if len(result) >= data['total_count']:
                     # We have retrieved all members, so stop sending API requests
                     break

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -123,16 +123,16 @@ class MailingList(models.Model):
         return {x.email for x in self.unsubscribed_set.all()}
 
     def _get_enrolled_email_set(self):
-        return {e['email'] for e in canvas_api_client.get_enrollments(self.canvas_course_id, self.section_id)}
+        return {e['email'].lower() for e in canvas_api_client.get_enrollments(self.canvas_course_id, self.section_id)}
 
     def _get_enrolled_teaching_staff_email_set(self):
-        return {e['email'] for e in canvas_api_client.get_teaching_staff_enrollments(self.canvas_course_id)}
+        return {e['email'].lower() for e in canvas_api_client.get_teaching_staff_enrollments(self.canvas_course_id)}
 
     def _get_whitelist_email_set(self):
-        return {x.email for x in EmailWhitelist.objects.all()}
+        return {x.email.lower() for x in EmailWhitelist.objects.all()}
 
     def _get_listserv_email_set(self):
-        return {m['address'] for m in listserv_client.members(self)}
+        return {m['address'].lower() for m in listserv_client.members(self)}
 
     @property
     def address(self):

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -123,10 +123,16 @@ class MailingList(models.Model):
         return {x.email for x in self.unsubscribed_set.all()}
 
     def _get_enrolled_email_set(self):
-        return {e['email'].lower() for e in canvas_api_client.get_enrollments(self.canvas_course_id, self.section_id)}
+        return {
+            e['email'].lower() for e in canvas_api_client.get_enrollments(self.canvas_course_id, self.section_id)
+            if e['email'] is not None
+        }
 
     def _get_enrolled_teaching_staff_email_set(self):
-        return {e['email'].lower() for e in canvas_api_client.get_teaching_staff_enrollments(self.canvas_course_id)}
+        return {
+            e['email'].lower() for e in canvas_api_client.get_teaching_staff_enrollments(self.canvas_course_id)
+            if e['email'] is not None
+        }
 
     def _get_whitelist_email_set(self):
         return {x.email.lower() for x in EmailWhitelist.objects.all()}


### PR DESCRIPTION
This addresses a production issue where HKS users were not able to send mail to mailgun mailing list addresses because their email clients were sending their addresses across with capitalized email user names. The fix here is to make sure we lower case all email addresses before comparing them.