### PR TITLE
Task/eparker71/tlt 1885 merge list for cross listed courses

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,6 +22,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # config.vm.network :forwarded_port, guest: 80, host: 8080
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000
+  config.vm.network :forwarded_port, guest: 5432, host: 5432
   config.vm.network :forwarded_port, guest: 8000, host: 8000, auto_correct: true
 
   # Create a private network, which allows host-only access to the machine

--- a/lti_emailer/canvas_api_client.py
+++ b/lti_emailer/canvas_api_client.py
@@ -43,12 +43,23 @@ def get_courses_for_account_in_term(account_id, enrollment_term_id,
     return result
 
 
-def get_enrollments(canvas_course_id, section_id):
+def get_enrollments(canvas_course_id, section_id=None):
+    """
+    Get the enrollments for a section if a section id is provided.
+    Otherwise get all enrollents for the course.
+    :param canvas_course_id:
+    :param section_id:
+    :return enrollments list:
+    """
     users = get_users_in_course(canvas_course_id)
     enrollments = []
     for user in users:
         for enrollment in user['enrollments']:
-            if enrollment['course_section_id'] == section_id:
+            if section_id:
+                if enrollment['course_section_id'] == section_id:
+                    _copy_user_attributes_to_enrollment(user, enrollment)
+                    enrollments.append(enrollment)
+            else:
                 _copy_user_attributes_to_enrollment(user, enrollment)
                 enrollments.append(enrollment)
     return enrollments

--- a/lti_emailer/canvas_api_client.py
+++ b/lti_emailer/canvas_api_client.py
@@ -60,7 +60,7 @@ def get_enrollments(canvas_course_id, section_id=None):
     for user in users:
         for enrollment in user['enrollments']:
             if section_id:
-                if str(enrollment['course_section_id']) == section_id:
+                if enrollment['course_section_id'] == int(section_id):
                     _copy_user_attributes_to_enrollment(user, enrollment)
                     enrollments.append(enrollment)
             else:
@@ -81,10 +81,12 @@ def get_name_for_email(canvas_course_id, address):
 
 
 def get_section(canvas_course_id, section_id):
-    sections = get_sections(canvas_course_id)
-    for section in sections:
-        if section['id'] == section_id:
-            return section
+    if section_id:
+        sections = get_sections(canvas_course_id)
+        section_id = int(section_id)
+        for section in sections:
+            if section['id'] == section_id:
+                return section
     return None
 
 

--- a/lti_emailer/canvas_api_client.py
+++ b/lti_emailer/canvas_api_client.py
@@ -26,6 +26,10 @@ TEACHING_STAFF_ENROLLMENT_TYPES = ['TeacherEnrollment', 'TaEnrollment', 'Designe
 USER_ATTRIBUTES_TO_COPY = [u'email', u'name', u'sortable_name']
 
 
+def get_course(canvas_course_id):
+    return canvas_api_helper_courses.get_course(canvas_course_id)
+
+
 def get_courses_for_account_in_term(account_id, enrollment_term_id,
                                     include_sections=False):
     kwargs = {

--- a/lti_emailer/canvas_api_client.py
+++ b/lti_emailer/canvas_api_client.py
@@ -60,12 +60,17 @@ def get_enrollments(canvas_course_id, section_id=None):
     for user in users:
         for enrollment in user['enrollments']:
             if section_id:
-                if enrollment['course_section_id'] == section_id:
+                if str(enrollment['course_section_id']) == section_id:
                     _copy_user_attributes_to_enrollment(user, enrollment)
                     enrollments.append(enrollment)
             else:
+                # if the user has any enrollment in the course
+                # we add them to the list and then stop (break)
+                # on to the next user.
                 _copy_user_attributes_to_enrollment(user, enrollment)
                 enrollments.append(enrollment)
+                break
+
     return enrollments
 
 
@@ -77,7 +82,6 @@ def get_name_for_email(canvas_course_id, address):
 
 def get_section(canvas_course_id, section_id):
     sections = get_sections(canvas_course_id)
-    section_id = int(section_id)
     for section in sections:
         if section['id'] == section_id:
             return section

--- a/lti_emailer/settings/base.py
+++ b/lti_emailer/settings/base.py
@@ -287,7 +287,8 @@ LISTSERV_DOMAIN = SECURE_SETTINGS.get('listserv_domain')
 LISTSERV_API_URL = SECURE_SETTINGS.get('listserv_api_url')
 LISTSERV_API_USER = SECURE_SETTINGS.get('listserv_api_user')
 LISTSERV_API_KEY = SECURE_SETTINGS.get('listserv_api_key')
-LISTSERV_ADDRESS_FORMAT = "canvas-{canvas_course_id}-{section_id}@%s" % LISTSERV_DOMAIN
+LISTSERV_SECTION_ADDRESS_FORMAT = "canvas-{canvas_course_id}-{section_id}@%s" % LISTSERV_DOMAIN
+LISTSERV_COURSE_ADDRESS_FORMAT = "canvas-{canvas_course_id}@%s" % LISTSERV_DOMAIN
 
 MAILGUN_CALLBACK_TIMEOUT = 30 * 1000  # 30 seconds
 

--- a/lti_emailer/settings/base.py
+++ b/lti_emailer/settings/base.py
@@ -289,7 +289,7 @@ LISTSERV_API_URL = SECURE_SETTINGS.get('listserv_api_url')
 LISTSERV_API_USER = SECURE_SETTINGS.get('listserv_api_user')
 LISTSERV_API_KEY = SECURE_SETTINGS.get('listserv_api_key')
 
-LISTSERV_SECTION_ADDRESS_RE = re.compile("^canvas-(?P<canvas_course_id>\d+)-(?P<section>\d+)@%s$" % LISTSERV_DOMAIN)
+LISTSERV_SECTION_ADDRESS_RE = re.compile("^canvas-(?P<canvas_course_id>\d+)-(?P<section_id>\d+)@%s$" % LISTSERV_DOMAIN)
 LISTSERV_COURSE_ADDRESS_RE = re.compile("^canvas-(?P<canvas_course_id>\d+)@%s$" % LISTSERV_DOMAIN)
 
 LISTSERV_SECTION_ADDRESS_FORMAT = "canvas-{canvas_course_id}-{section_id}@%s" % LISTSERV_DOMAIN

--- a/lti_emailer/settings/base.py
+++ b/lti_emailer/settings/base.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/1.8/ref/settings/
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
+import re
 import logging
 from django.core.urlresolvers import reverse_lazy
 from .secure import SECURE_SETTINGS
@@ -287,6 +288,11 @@ LISTSERV_DOMAIN = SECURE_SETTINGS.get('listserv_domain')
 LISTSERV_API_URL = SECURE_SETTINGS.get('listserv_api_url')
 LISTSERV_API_USER = SECURE_SETTINGS.get('listserv_api_user')
 LISTSERV_API_KEY = SECURE_SETTINGS.get('listserv_api_key')
+
+LISTSERV_SECTION_ADDRESS_RE = re.compile("^canvas-(?P<canvas_course_id>\d+)-(?P<section>\d+)@%s$" % LISTSERV_DOMAIN)
+LISTSERV_COURSE_ADDRESS_RE = re.compile("^canvas-(?P<canvas_course_id>\d+)@%s$" % LISTSERV_DOMAIN)
+
+
 LISTSERV_SECTION_ADDRESS_FORMAT = "canvas-{canvas_course_id}-{section_id}@%s" % LISTSERV_DOMAIN
 LISTSERV_COURSE_ADDRESS_FORMAT = "canvas-{canvas_course_id}@%s" % LISTSERV_DOMAIN
 

--- a/lti_emailer/settings/base.py
+++ b/lti_emailer/settings/base.py
@@ -292,7 +292,6 @@ LISTSERV_API_KEY = SECURE_SETTINGS.get('listserv_api_key')
 LISTSERV_SECTION_ADDRESS_RE = re.compile("^canvas-(?P<canvas_course_id>\d+)-(?P<section>\d+)@%s$" % LISTSERV_DOMAIN)
 LISTSERV_COURSE_ADDRESS_RE = re.compile("^canvas-(?P<canvas_course_id>\d+)@%s$" % LISTSERV_DOMAIN)
 
-
 LISTSERV_SECTION_ADDRESS_FORMAT = "canvas-{canvas_course_id}-{section_id}@%s" % LISTSERV_DOMAIN
 LISTSERV_COURSE_ADDRESS_FORMAT = "canvas-{canvas_course_id}@%s" % LISTSERV_DOMAIN
 

--- a/mailing_list/api.py
+++ b/mailing_list/api.py
@@ -88,25 +88,3 @@ def set_access_level(request, mailing_list_id):
     return create_json_200_response(result)
 
 
-@login_required
-@lti_role_required(const.TEACHING_STAFF_ROLES)
-@has_course_permission(canvas_api_helper_courses.COURSE_PERMISSION_SEND_MESSAGES_ALL)
-@require_http_methods(['GET'])
-def get_course(request):
-    """
-    Gets the current canvas course
-
-    :param request:
-    :return: JSON response containing the course object
-    """
-    try:
-        canvas_course_id = request.LTI['custom_canvas_course_id']
-        course = canvas_api_helper_courses.get_course(canvas_course_id)
-
-    except Exception:
-        message = "Failed to get_course with LTI params %s" % json.dumps(request.LTI)
-        logger.exception(message)
-        return create_json_500_response(message)
-
-    return create_json_200_response(course)
-

--- a/mailing_list/api.py
+++ b/mailing_list/api.py
@@ -42,6 +42,7 @@ def lists(request):
                 'modified_by': logged_in_user_id
             }
         )
+
     except Exception:
         message = "Failed to get_or_create MailingLists with LTI params %s" % json.dumps(request.LTI)
         logger.exception(message)
@@ -85,3 +86,27 @@ def set_access_level(request, mailing_list_id):
         return create_json_500_response(message)
 
     return create_json_200_response(result)
+
+
+@login_required
+@lti_role_required(const.TEACHING_STAFF_ROLES)
+@has_course_permission(canvas_api_helper_courses.COURSE_PERMISSION_SEND_MESSAGES_ALL)
+@require_http_methods(['GET'])
+def get_course(request):
+    """
+    Gets the current canvas course
+
+    :param request:
+    :return: JSON response containing the course object
+    """
+    try:
+        canvas_course_id = request.LTI['custom_canvas_course_id']
+        course = canvas_api_helper_courses.get_course(canvas_course_id)
+
+    except Exception:
+        message = "Failed to get_course with LTI params %s" % json.dumps(request.LTI)
+        logger.exception(message)
+        return create_json_500_response(message)
+
+    return create_json_200_response(course)
+

--- a/mailing_list/migrations/0011_auto_20150905_1942.py
+++ b/mailing_list/migrations/0011_auto_20150905_1942.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mailing_list', '0010_auto_20150827_1712'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='mailinglist',
+            name='section_id',
+            field=models.CharField(max_length=32),
+        ),
+    ]

--- a/mailing_list/migrations/0011_auto_20150908_1505.py
+++ b/mailing_list/migrations/0011_auto_20150908_1505.py
@@ -14,6 +14,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='mailinglist',
             name='section_id',
-            field=models.CharField(max_length=32),
+            field=models.IntegerField(null=True),
         ),
     ]

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -95,6 +95,9 @@ class MailingListManager(models.Manager):
             try:
                 course_list = MailingList.objects.get(canvas_course_id=canvas_course_id, section_id__isnull=True)
             except MailingList.DoesNotExist:
+                course_list = None
+
+            if not course_list:
                 create_kwargs = {
                     'canvas_course_id': canvas_course_id,
                     'section_id': None

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -93,8 +93,8 @@ class MailingListManager(models.Manager):
         course_list = None
         if len(primary_sections) > 1:
             try:
-                course_list = MailingList.objects.get(canvas_course_id=canvas_course_id, section_id__isnull=True)
-            except MailingList.DoesNotExist:
+                course_list = mailing_lists_by_section_id.pop(None)
+            except KeyError:
                 course_list = None
 
             if not course_list:

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -150,9 +150,7 @@ class MailingListManager(models.Manager):
 
         # Delete existing mailing lists who's section no longer exists
         for section_id, mailing_list in mailing_lists_by_section_id.iteritems():
-            # we don't want to delete the course list here
-            if section_id:
-                mailing_list.delete()
+            mailing_list.delete()
 
         return result
 

--- a/mailing_list/static/mailing_list/js/app.js
+++ b/mailing_list/static/mailing_list/js/app.js
@@ -30,31 +30,31 @@
         ml.updatedAccessLevel = '';
         ml.accessLevels = [{
             id: 'staff',
-            name: {class: 'Staff Access', section: 'Staff Access Only'},
+            name: {class: 'Staff Access:', section: 'Staff Access:'},
             description: {
-                class: 'For staff to email members of this course; students and guests <b>cannot</b> send or reply to this mailing list.',
-                section: 'For staff to email members of this course; students and guests <b>cannot</b> send or reply to this mailing list.'
+                class: 'staff can email members of this course; students and guests <strong>cannot</strong> send or reply to this mailing list.',
+                section: 'staff can email members of this course; students and guests <strong>cannot</strong> send or reply to this mailing list.'
             }
         },{
             id: 'members',
-            name: {class: 'Course Access', section: 'Section Access'},
+            name: {class: 'Course Access:', section: 'Section Access:'},
             description: {
-                class: 'For all members of this course to email each other; students and guests <b>can</b> send and reply to this mailing list.',
-                section: 'For members of this section and all staff to email each other; students and guests in this section <b>can</b> send and reply to this mailing list.'
+                class: 'all members of this course can email each other; students and guests <strong>can</strong> send and reply to this mailing list.',
+                section: 'all members of this section and all staff can email each other; students and guests <strong>can</strong> send and reply to this mailing list.'
             }
         },{
             id: 'everyone',
-            name: {class: 'World Access', section: 'World Access'},
+            name: {class: 'World Access:', section: 'World Access:'},
             description: {
-                class: 'Anyone can send and reply to this mailing list.',
-                section: 'Anyone can send and reply to this mailing list.'
+                class: 'anyone can send and reply to this mailing list.',
+                section: 'anyone can send and reply to this mailing list.'
             }
         },{
             id: 'readonly',
-            name: {class: 'Disabled', section: 'Disabled'},
+            name: {class: 'Disabled:', section: 'Disabled:'},
             description: {
-                class: 'This mailing list is disabled.',
-                section: 'This mailing list is disabled.'
+                class: 'this mailing list is disabled.',
+                section: 'his mailing list is disabled.'
             }
         }];
         ml.accessLevelDisplayNameMap = {};

--- a/mailing_list/static/mailing_list/js/app.js
+++ b/mailing_list/static/mailing_list/js/app.js
@@ -91,6 +91,10 @@
             return ml.otherSectionLists.length > 0;
         };
 
+        ml.isCourseList = function(list){
+          return list.section_id == 0;
+        };
+
         ml.updateAccessLevel = function(list) {
             $('#permissions-modal-' + list.section_id).modal('hide');
             list.isUpdating = true;

--- a/mailing_list/static/mailing_list/js/app.js
+++ b/mailing_list/static/mailing_list/js/app.js
@@ -18,13 +18,11 @@
     app.controller('MailingListController', ['$http', '$timeout', 'djangoUrl', function($http, $timeout, $djangoUrl){
         var ml = this;
         var URL_LISTS = $djangoUrl.reverse('mailing_list:api_lists');
-        var GET_COURSE = $djangoUrl.reverse('mailing_list:api_course');
 
         ml.isLoading = true;
         ml.isUpdating = false;
         ml.primarySectionLists = [];
         ml.otherSectionLists = [];
-        ml.course_code = null;
         // temp storage for modal interaction to access level to prevent base
         // page from updating until the requested change has been saved via AJAX
         ml.updatedAccessLevel = '';
@@ -79,10 +77,6 @@
             ml.loaded = true;
         });
 
-        $http.get(GET_COURSE).success(function(data){
-            ml.course_code = data.course_code;
-        });
-
         ml.hasMultiplePrimarySections = function() {
           return ml.primarySectionLists.length > 1;
         };
@@ -96,7 +90,10 @@
         };
 
         ml.isCourseList = function(list){
-          return list.section_id == 'None';
+            if(typeof list.is_course_list !== 'undefined'){
+                return list.is_course_list == true;
+            }
+            return false;
         };
 
         ml.updateAccessLevel = function(list) {
@@ -124,9 +121,14 @@
         };
 
         ml.listMembersUrl = function(list) {
-            return window.globals.append_resource_link_id(
-                       $djangoUrl.reverse('mailing_list:list_members',
-                                          [list.section_id]));
+            if(list.section_id) {
+                return window.globals.append_resource_link_id(
+                  $djangoUrl.reverse('mailing_list:list_members',
+                    [list.section_id]));
+            }else{
+                return window.globals.append_resource_link_id(
+                  $djangoUrl.reverse('mailing_list:list_members_no_id'));
+            }
         };
     }]);
 })();

--- a/mailing_list/static/mailing_list/js/app.js
+++ b/mailing_list/static/mailing_list/js/app.js
@@ -18,11 +18,13 @@
     app.controller('MailingListController', ['$http', '$timeout', 'djangoUrl', function($http, $timeout, $djangoUrl){
         var ml = this;
         var URL_LISTS = $djangoUrl.reverse('mailing_list:api_lists');
+        var GET_COURSE = $djangoUrl.reverse('mailing_list:api_course');
 
         ml.isLoading = true;
         ml.isUpdating = false;
         ml.primarySectionLists = [];
         ml.otherSectionLists = [];
+        ml.course_code = null;
         // temp storage for modal interaction to access level to prevent base
         // page from updating until the requested change has been saved via AJAX
         ml.updatedAccessLevel = '';
@@ -75,6 +77,10 @@
                 }
             }
             ml.loaded = true;
+        });
+
+        $http.get(GET_COURSE).success(function(data){
+            ml.course_code = data.course_code;
         });
 
         ml.hasPrimarySections = function() {

--- a/mailing_list/static/mailing_list/js/app.js
+++ b/mailing_list/static/mailing_list/js/app.js
@@ -54,7 +54,7 @@
             name: {class: 'Disabled:', section: 'Disabled:'},
             description: {
                 class: 'this mailing list is disabled.',
-                section: 'his mailing list is disabled.'
+                section: 'this mailing list is disabled.'
             }
         }];
         ml.accessLevelDisplayNameMap = {};

--- a/mailing_list/static/mailing_list/js/app.js
+++ b/mailing_list/static/mailing_list/js/app.js
@@ -83,6 +83,10 @@
             ml.course_code = data.course_code;
         });
 
+        ml.hasMultiplePrimarySections = function() {
+          return ml.primarySectionLists.length > 1;
+        };
+
         ml.hasPrimarySections = function() {
             return ml.primarySectionLists.length > 0;
         };
@@ -92,7 +96,7 @@
         };
 
         ml.isCourseList = function(list){
-          return list.section_id == 0;
+          return list.section_id == 'None';
         };
 
         ml.updateAccessLevel = function(list) {

--- a/mailing_list/templates/mailing_list/_mailing_list_details.html
+++ b/mailing_list/templates/mailing_list/_mailing_list_details.html
@@ -13,14 +13,23 @@
         title=""
         data-original-title="Members emails"
         data-toggle="tooltip"
-        href="{{ ml.listMembersUrl(list) }}"><ng-pluralize count="list.members_count" when="{'0': 'No members', 'one': '1 member', 'other': '{} members'}"></ng-pluralize></a>)
+        href="{{ ml.listMembersUrl(list) }}">
+      <ng-pluralize count="list.members_count"
+                    when="{'0': 'No members', 'one': '1 member', 'other': '{} members'}"></ng-pluralize></a>)
   </p>
 </div>
 
 <!-- column 2 -->
 <div class="col-md-3">
   <p ng-class="list.access_level == 'readonly' ? 'caption-disabled' : ''">
-    <a id="email-section-{{ list.section_id }}" target="_top" href="mailto:{{ list.address }}" ng-disabled="list.access_level == 'readonly'" class="ng-binding editSection lti-tooltip" rel="tooltip" data-toggle="tooltip" title="" data-original-title="Click this link to send an email">
+    <a id="email-section-{{ list.section_id }}"
+       target="_top"
+       href="mailto:{{ list.address }}"
+       ng-disabled="list.access_level == 'readonly'"
+       class="ng-binding editSection lti-tooltip"
+       rel="tooltip"
+       data-toggle="tooltip"
+       title="" data-original-title="Click this link to send an email">
        <i class="fa fa-envelope"></i> {{ list.address }}
     </a>
   </p>
@@ -31,7 +40,9 @@
 <!-- column 3 -->
 <div class="col-md-5">
     <p>
-        <strong ng-bind="ml.accessLevelDisplayNameMap[list.access_level]['{{ scope }}']"></strong> - <span ng-bind-html="ml.accessLevelDescriptionMap[list.access_level]['{{ scope }}']"></span>
+        <strong
+                ng-bind="ml.accessLevelDisplayNameMap[list.access_level]['{{ scope }}']">
+        </strong> - <span ng-bind-html="ml.accessLevelDescriptionMap[list.access_level]['{{ scope }}']"></span>
     </p>
 </div>
 
@@ -83,7 +94,8 @@
                 If you would like a copy of your email, add your own email address to the CC or BCC field.
               </p>
               <p ng-show="!list.is_primary_section" class="caption">
-                Any email sent to a section will be delivered to all staff in the course, even if they have not been added to the section.
+                Any email sent to a section will be delivered to all staff in the course, even if they
+                  have not been added to the section.
               </p>
               <div id="permissions-input-{{ list.section_id }}">
                   <div class="indented-radio-block"

--- a/mailing_list/templates/mailing_list/_mailing_list_details.html
+++ b/mailing_list/templates/mailing_list/_mailing_list_details.html
@@ -1,27 +1,27 @@
 {% load static %}
 
+<div class="col-md-12">
+    <hr width="98%">
+</div>
 
-<hr width="98%">
 {% verbatim %}
-
+<!-- 4 column row  -->
 <!-- column 1 -->
 <div class="col-md-3">
   <p>
-    <strong>{{ list.name }}</strong>
-    (<a class="link-text lti-tooltip"
+    <strong>{{ list.name }}</strong><br />(<a class="link-text lti-tooltip"
         rel="tooltip"
         title=""
         data-original-title="Members emails"
         data-toggle="tooltip"
-        href="{{ ml.listMembersUrl(list) }}">
-      <ng-pluralize count="list.members_count"
+        href="{{ ml.listMembersUrl(list) }}"><ng-pluralize count="list.members_count"
                     when="{'0': 'No members', 'one': '1 member', 'other': '{} members'}"></ng-pluralize></a>)
   </p>
 </div>
 
 <!-- column 2 -->
 <div class="col-md-3">
-  <p ng-class="list.access_level == 'readonly' ? 'caption-disabled' : ''">
+  <p ng-class="list.access_level == 'readonly' ? 'caption-disabled' : ''" style="word-wrap:break-word;">
     <a id="email-section-{{ list.section_id }}"
        target="_top"
        href="mailto:{{ list.address }}"
@@ -129,4 +129,3 @@
       </div><!-- /.modal-content -->
     </div><!-- /.modal-dialog -->
   </div><!-- /.modal -->
-</div>

--- a/mailing_list/templates/mailing_list/_mailing_list_details.html
+++ b/mailing_list/templates/mailing_list/_mailing_list_details.html
@@ -21,7 +21,7 @@
 <div class="col-md-3">
   <p ng-class="list.access_level == 'readonly' ? 'caption-disabled' : ''">
     <a id="email-section-{{ list.section_id }}" target="_top" href="mailto:{{ list.address }}" ng-disabled="list.access_level == 'readonly'" class="ng-binding editSection lti-tooltip" rel="tooltip" data-toggle="tooltip" title="" data-original-title="Click this link to send an email">
-       <i class="fa fa-envelope"></i> {{ list.address | limitTo: 15 }}{{list.address.length > 15 ? '...' : ''}}
+       <i class="fa fa-envelope"></i> {{ list.address }}
     </a>
   </p>
 </div>
@@ -76,36 +76,43 @@
                 Change Permissions
               </label>
             </h4>
+
           </div>
           <div class="modal-body">
-            <div id="permissions-input-{{ list.section_id }}">
-              <div class="indented-radio-block"
-                   ng-repeat="access_level in ml.accessLevels">
-                <input type="radio"
-                       class="indented-radio-block-input"
-                       id="permissions-radio-{{ list.section_id }}-{{ access_level.id }}"
-                       ng-model="ml.updatedAccessLevel"
-                       value="{{ access_level.id }}">
-                <label class="indented-radio-block-label"
-                       for="permissions-radio-{{ list.section_id }}-{{ access_level.id }}">
+              <p class="caption">
+                If you would like a copy of your email, add your own email address to the CC or BCC field.
+              </p>
+              <p ng-show="!list.is_primary_section" class="caption">
+                Any email sent to a section will be delivered to all staff in the course, even if they have not been added to the section.
+              </p>
+              <div id="permissions-input-{{ list.section_id }}">
+                  <div class="indented-radio-block"
+                       ng-repeat="access_level in ml.accessLevels">
+                      <input type="radio"
+                             class="indented-radio-block-input"
+                             id="permissions-radio-{{ list.section_id }}-{{ access_level.id }}"
+                             ng-model="ml.updatedAccessLevel"
+                             value="{{ access_level.id }}">
+                      <label class="indented-radio-block-label"
+                             for="permissions-radio-{{ list.section_id }}-{{ access_level.id }}">
 {% endverbatim %}
-                  <span ng-bind="access_level.name['{{ scope }}']"></span>
-                </label>
-                  <span ng-bind-html="access_level.description['{{ scope }}']"></span>
-                <br/>
+                          <span ng-bind="access_level.name['{{ scope }}']"></span>
+                      </label>
+                      <span ng-bind-html="access_level.description['{{ scope }}']"></span>
+                      <br/>
+                  </div>
               </div>
-            </div>
           </div>
-          <div class="modal-footer">
-            <div class="ic-Form-actions">
-              <a href="#" data-dismiss="modal">Cancel</a>
-              <button type="button"
-                      class="btn btn-primary btn-submit"
-                      ng-click="ml.updateAccessLevel(list)">
-                Update Permissions
-              </button>
+            <div class="modal-footer">
+                <div class="ic-Form-actions">
+                    <a href="#" data-dismiss="modal">Cancel</a>
+                    <button type="button"
+                            class="btn btn-primary btn-submit"
+                            ng-click="ml.updateAccessLevel(list)">
+                        Update Permissions
+                    </button>
+                </div>
             </div>
-          </div>
         </form>
       </div><!-- /.modal-content -->
     </div><!-- /.modal-dialog -->

--- a/mailing_list/templates/mailing_list/_mailing_list_details.html
+++ b/mailing_list/templates/mailing_list/_mailing_list_details.html
@@ -1,35 +1,62 @@
 {% load static %}
 
+
+<hr width="98%">
 {% verbatim %}
-<div>
+
+<!-- column 1 -->
+<div class="col-md-3">
   <p>
     <strong>{{ list.name }}</strong>
-    (<a class="link-text" href="{{ ml.listMembersUrl(list) }}"><ng-pluralize count="list.members_count" when="{'0': 'No members', 'one': '1 member', 'other': '{} members'}"></ng-pluralize></a>)
+    (<a class="link-text lti-tooltip"
+        rel="tooltip"
+        title=""
+        data-original-title="Members emails"
+        data-toggle="tooltip"
+        href="{{ ml.listMembersUrl(list) }}"><ng-pluralize count="list.members_count" when="{'0': 'No members', 'one': '1 member', 'other': '{} members'}"></ng-pluralize></a>)
   </p>
 </div>
-<div class="float-left col-40" style="padding-left: 0;">
+
+<!-- column 2 -->
+<div class="col-md-3">
   <p ng-class="list.access_level == 'readonly' ? 'caption-disabled' : ''">
-    <a id="email-section-{{ list.section_id }}" target="_top" href="mailto:{{ list.address }}" ng-disabled="list.access_level == 'readonly'">
-       <i class="fa fa-envelope"></i> {{ list.address }}
+    <a id="email-section-{{ list.section_id }}" target="_top" href="mailto:{{ list.address }}" ng-disabled="list.access_level == 'readonly'" class="ng-binding editSection lti-tooltip" rel="tooltip" data-toggle="tooltip" title="" data-original-title="Click this link to send an email">
+       <i class="fa fa-envelope"></i> {{ list.address | limitTo: 15 }}{{list.address.length > 15 ? '...' : ''}}
     </a>
   </p>
 </div>
+
 {% endverbatim %}
-<div class="float-left col-60">
-  <div class="float-left col-60">
+
+<!-- column 3 -->
+<div class="col-md-5">
     <p>
-      <strong ng-bind="ml.accessLevelDisplayNameMap[list.access_level]['{{ scope }}']"></strong> - <span ng-bind-html="ml.accessLevelDescriptionMap[list.access_level]['{{ scope }}']"></span>
+        <strong ng-bind="ml.accessLevelDisplayNameMap[list.access_level]['{{ scope }}']"></strong> - <span ng-bind-html="ml.accessLevelDescriptionMap[list.access_level]['{{ scope }}']"></span>
     </p>
-  </div>
-  <div class="float-left col-40">
-{% verbatim %}
-    <button class="btn btn-submit" data-toggle="modal" data-target="#permissions-modal-{{ list.section_id }}" ng-click="ml.updatedAccessLevel = list.access_level"><i class="fa fa-gear"></i> Change</button>
-{% endverbatim %}
+</div>
+
+<!-- column 4 -->
+<div class="col-md-1 editMenu">
+    {% verbatim %}
+    <a href="#"
+       class="editSection lti-tooltip"
+       rel="tooltip"
+       data-toggle="modal"
+       data-target="#permissions-modal-{{ list.section_id }}"
+       ng-click="ml.updatedAccessLevel = list.access_level"
+       title="Edit {{ list.name }}"
+       data-original-title="Edit {{ list.name }}">
+        <i class="fa fa-gear"></i>
+    </a>
+    {% endverbatim %}
     <img src="{% static 'images/ajax-loader-small.gif' %}" ng-show="list.isUpdating" class="ng-hide">
     <span class="text-success feedback ng-hide" ng-show="list.updated">✓</span>
     <span class="text-danger feedback ng-hide" ng-show="list.update_failed">✗</span>
-  </div>
 </div>
+
+
+<!-- Modal -->
+
 {% verbatim %}
   <div id="permissions-modal-{{ list.section_id }}" class="modal fade">
 {% endverbatim %}

--- a/mailing_list/templates/mailing_list/admin_index.html
+++ b/mailing_list/templates/mailing_list/admin_index.html
@@ -37,9 +37,7 @@ $(document).ready(function(){
     <main class="ng-hide" ng-show="ml.loaded">
 
         <div ng-show="ml.hasPrimarySections()" class="col-md-12">
-        {% verbatim %}
-          <h2>Mailing List for {{ml.course_code}}</h2>
-        {% endverbatim %}
+          <h2>Mailing List for {{course_code}}</h2>
             <p class="caption">
                 The mailing list contains staff, students, and guests who have been added to this course.
                 <a target="_blank"
@@ -70,8 +68,7 @@ $(document).ready(function(){
             <!--<hr width="98%">-->
             <!-- show combined mailing list or single primary list -->
             <!-- if there is a combined mailing list show it -->
-            <div ng-if="ml.isCourseList(list)"
-               ng-repeat="list in ml.primarySectionLists">
+            <div ng-if="ml.isCourseList(list)" ng-repeat="list in ml.primarySectionLists">
               {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
                 <div class="col-md-12">
                     <hr width="98%">
@@ -96,15 +93,15 @@ $(document).ready(function(){
                   <div class="panel panel-default" ng-show="ml.hasPrimarySections()">
                       <div class="panel-heading" role="tab" id="headingOne">
                           <h4 class="panel-title">
-                              {% verbatim %}
+
                               <a class="collapsed"
                                  role="button"
                                  data-toggle="collapse"
                                  data-parent="#accordion"
                                  href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
-                                  Official Course Sections for {{ml.course_code}}
+                                  Official Course Sections for {{course_code}}
                               </a>
-                              {% endverbatim %}
+
                           </h4>
                       </div>
 
@@ -128,7 +125,7 @@ $(document).ready(function(){
                   <div class="panel panel-default" ng-show="ml.hasOtherSections">
                       <div class="panel-heading" role="tab" id="headingOne">
                           <h4 class="panel-title">
-                              {% verbatim %}
+
                               <a class="collapsed"
                                  role="button"
                                  data-toggle="collapse"
@@ -138,9 +135,9 @@ $(document).ready(function(){
                                   <ng-pluralize count="ml.otherSectionLists.length"
                                                 when="{'0': 'No Sections for ', 'one': '1 Section for ', 'other': '{} Sections for '}">
 
-                                  </ng-pluralize>{{ml.course_code}}
+                                  </ng-pluralize>{{course_code}}
                               </a>
-                              {% endverbatim %}
+
                           </h4>
                       </div>
 

--- a/mailing_list/templates/mailing_list/admin_index.html
+++ b/mailing_list/templates/mailing_list/admin_index.html
@@ -41,10 +41,22 @@ $(document).ready(function(){
       {% endverbatim %}
       <p class="caption">
         The mailing list contains staff, students, and guests who have been added to this course.
-        <a target="_blank" href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer " class="lti-tooltip" rel="tooltip" data-toggle="tooltip" title="" data-original-title="More info about the Course Emailer"><i class="fa fa-question-circle"></i></a>
+        <a target="_blank"
+           href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer "
+           class="lti-tooltip"
+           rel="tooltip"
+           data-toggle="tooltip"
+           title=""
+           data-original-title="More info about the Course Emailer"><i class="fa fa-question-circle"></i></a>
         <div ng-show="ml.hasPrimarySections()">
           This course site includes enrollment from two or more schools.
-          <a target="_blank" href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer" class="lti-tooltip" rel="tooltip" data-toggle="tooltip" title="" data-original-title="More info about cross listed courses"><i class="fa fa-question-circle"></i></a>
+          <a target="_blank"
+             href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer"
+             class="lti-tooltip"
+             rel="tooltip"
+             data-toggle="tooltip"
+             title=""
+             data-original-title="More info about cross listed courses"><i class="fa fa-question-circle"></i></a>
         </div>
       </p>
     </div>
@@ -52,7 +64,8 @@ $(document).ready(function(){
     <hr width="98%">
     <!-- show combined mailing list or single primary list -->
     <!-- if there is a combined mailing list show it -->
-    <div ng-if="ml.primarySectionLists.length > 1 && list.section_id == 0" ng-repeat="list in ml.primarySectionLists">
+    <div ng-if="ml.primarySectionLists.length > 1 && list.section_id == 0"
+         ng-repeat="list in ml.primarySectionLists">
       {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
     </div>
     <!-- otherwise show the primary section -->
@@ -76,7 +89,11 @@ $(document).ready(function(){
           <div class="panel-heading" role="tab" id="headingOne">
             <h4 class="panel-title">
               {% verbatim %}
-              <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+              <a class="collapsed"
+                 role="button"
+                 data-toggle="collapse"
+                 data-parent="#accordion"
+                 href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
                       Official Course Sections for {{ml.course_code}}
               </a>
               {% endverbatim %}
@@ -102,8 +119,15 @@ $(document).ready(function(){
           <div class="panel-heading" role="tab" id="headingOne">
             <h4 class="panel-title">
               {% verbatim %}
-              <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
-                <ng-pluralize count="ml.otherSectionLists.length" when="{'0': 'No Sections for ', 'one': '1 Section for ', 'other': '{} Sections for '}"></ng-pluralize>{{ml.course_code}}
+              <a class="collapsed"
+                 role="button"
+                 data-toggle="collapse"
+                 data-parent="#accordion"
+                 href="#collapseTwo"
+                 aria-expanded="false" aria-controls="collapseTwo">
+                <ng-pluralize count="ml.otherSectionLists.length"
+                              when="{'0': 'No Sections for ', 'one': '1 Section for ', 'other': '{} Sections for '}">
+                </ng-pluralize>{{ml.course_code}}
               </a>
               {% endverbatim %}
              </h4>
@@ -113,10 +137,14 @@ $(document).ready(function(){
               <div class="col-md-12">
                 <h2>Sections</h2>
                 <p class="caption">
-                  If you would like a copy of your email, add your own email address to the CC or BCC field. Any email sent to a section will be delivered to all staff in the course, even if they have not been added to the section.
+                  If you would like a copy of your email, add your own email address to the CC or BCC field.
+                  Any email sent to a section will be delivered to all staff in the course, even if they have
+                  not been added to the section.
                 </p>
                 <p class="caption">
-                  These sections are created in the Manage Sections tool (if installed in your account) or are being sent from the Registrar's Office. Any changes made to those sections will be reflected within these lists.
+                  These sections are created in the Manage Sections tool (if installed in your account) or are being
+                  sent from the Registrar's Office. Any changes made to those sections will be reflected
+                  within these lists.
                 </p>
               </div>
               <div class="content-section" ng-repeat="list in ml.otherSectionLists">

--- a/mailing_list/templates/mailing_list/admin_index.html
+++ b/mailing_list/templates/mailing_list/admin_index.html
@@ -90,7 +90,7 @@ $(document).ready(function(){
 
             <div class="btn-group col-md-12">
               <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-                  <div class="panel panel-default" ng-show="ml.hasPrimarySections()">
+                  <div class="panel panel-default" ng-show="ml.hasMultiplePrimarySections()">
                       <div class="panel-heading" role="tab" id="headingOne">
                           <h4 class="panel-title">
 
@@ -122,7 +122,7 @@ $(document).ready(function(){
                       </div>
                   </div>
 
-                  <div class="panel panel-default" ng-show="ml.hasOtherSections">
+                  <div class="panel panel-default" ng-show="ml.hasOtherSections()">
                       <div class="panel-heading" role="tab" id="headingOne">
                           <h4 class="panel-title">
 

--- a/mailing_list/templates/mailing_list/admin_index.html
+++ b/mailing_list/templates/mailing_list/admin_index.html
@@ -41,8 +41,8 @@ $(document).ready(function(){
       {% endverbatim %}
       <p class="caption">
         The mailing list contains staff, students, and guests who have been added to this course.
-        <a target="_blank" href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer " title="More info about the Course Emailer"><i class="fa fa-question-circle"></i></a>
-        <div ng-show="ml.primarySectionLists.length > 1">
+        <a target="_blank" href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer " class="lti-tooltip" rel="tooltip" data-toggle="tooltip" title="" data-original-title="More info about the Course Emailer"><i class="fa fa-question-circle"></i></a>
+        <div ng-show="ml.hasPrimarySections()">
           This course site includes enrollment from two or more schools.
           <a target="_blank" href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer" class="lti-tooltip" rel="tooltip" data-toggle="tooltip" title="" data-original-title="More info about cross listed courses"><i class="fa fa-question-circle"></i></a>
         </div>
@@ -71,11 +71,8 @@ $(document).ready(function(){
     </div>
 
     <div class="btn-group col-md-12">
-
       <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-
         <div class="panel panel-default" ng-show="ml.primarySectionLists.length > 1">
-
           <div class="panel-heading" role="tab" id="headingOne">
             <h4 class="panel-title">
               {% verbatim %}
@@ -91,7 +88,7 @@ $(document).ready(function(){
               <div class="col-md-12">
                 <h2>Official Course Sections</h2>
                 <p class="caption">
-                    Click these links to email the enrollees from individual schools.
+                    These mailing lists contains staff, students, and guests from individual schools.
                 </p>
               </div>
               <div  ng-repeat="list in ml.primarySectionLists" ng-if="list.section_id > 0">
@@ -116,7 +113,10 @@ $(document).ready(function(){
               <div class="col-md-12">
                 <h2>Sections</h2>
                 <p class="caption">
-                    These sections are created in the Manage Sections tool (if installed in your account) or are being sent from the Registrar's Office. Any changes made to those sections will be reflected within these lists.
+                  If you would like a copy of your email, add your own email address to the CC or BCC field. Any email sent to a section will be delivered to all staff in the course, even if they have not been added to the section.
+                </p>
+                <p class="caption">
+                  These sections are created in the Manage Sections tool (if installed in your account) or are being sent from the Registrar's Office. Any changes made to those sections will be reflected within these lists.
                 </p>
               </div>
               <div class="content-section" ng-repeat="list in ml.otherSectionLists">

--- a/mailing_list/templates/mailing_list/admin_index.html
+++ b/mailing_list/templates/mailing_list/admin_index.html
@@ -51,7 +51,7 @@ $(document).ready(function(){
                    data-original-title="More info about the Course Emailer">
                     <i class="fa fa-question-circle"></i>
                 </a>
-                <div ng-show="ml.hasPrimarySections()">
+                <div ng-show="ml.hasMultiplePrimarySections()">
                     This course site includes enrollment from two or more schools.
                     <a target="_blank"
                        href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer"
@@ -70,7 +70,7 @@ $(document).ready(function(){
             <!--<hr width="98%">-->
             <!-- show combined mailing list or single primary list -->
             <!-- if there is a combined mailing list show it -->
-            <div ng-if="ml.hasPrimarySections() && ml.isCourseList(list)"
+            <div ng-if="ml.isCourseList(list)"
                ng-repeat="list in ml.primarySectionLists">
               {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
                 <div class="col-md-12">

--- a/mailing_list/templates/mailing_list/admin_index.html
+++ b/mailing_list/templates/mailing_list/admin_index.html
@@ -2,44 +2,134 @@
 
 {% load static %}
 
+{% block js %}
+<script type="text/javascript">
+$(document).ready(function(){
+    //tooltip for buttons (done this way because of dynamically created icons)
+    $('body').tooltip({
+        selector: '[rel=tooltip]'
+    });
+    $('[rel=tooltip]').tooltip({
+        container: 'body'
+    });
+});
+</script>
+{% endblock js %}
+
 {% block body %}
 <body class="lti-tool"
       role="application"
       ng-controller="MailingListController as ml">
+
   <header>
-    <h1>
-      {% block breadcrumbs %}Course Emailer{% endblock breadcrumbs %}
-    </h1>
+    <div class="row lti-header">
+      <h1>
+        {% block breadcrumbs %}Course Emailer{% endblock breadcrumbs %}
+      </h1>
+    </div>
   </header>
+
   <div class="loading-indicator" ng-show="ml.isLoading">
     <img src="{% static 'images/ajax-loader-large.gif' %}"/>
   </div>
+
   <main class="ng-hide" ng-show="ml.loaded">
-    <div ng-show="ml.hasPrimarySections()">
-      <h2><strong>Official course mailing list:</strong></h2>
+
+    <div ng-show="ml.hasPrimarySections()" class="col-md-12">
+      {% verbatim %}
+      <h2>Mailing List for {{ml.course_code}}</h2>
+      {% endverbatim %}
       <p class="caption">
         The mailing list contains staff, students, and guests who have been added to this course.
         <a target="_blank" href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer " title="More info about the Course Emailer"><i class="fa fa-question-circle"></i></a>
+        <div ng-show="ml.primarySectionLists.length > 1">
+          This course site includes enrollment from two or more schools.
+          <a target="_blank" href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer" class="lti-tooltip" rel="tooltip" data-toggle="tooltip" title="" data-original-title="More info about cross listed courses"><i class="fa fa-question-circle"></i></a>
+        </div>
       </p>
-      <div ng-repeat="list in ml.primarySectionLists">
-        {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
-      </div>
     </div>
-    <div ng-show="!ml.hasPrimarySections()">
+
+    <hr width="98%">
+    <!-- show combined mailing list or single primary list -->
+    <!-- if there is a combined mailing list show it -->
+    <div ng-if="ml.primarySectionLists.length > 1 && list.section_id == 0" ng-repeat="list in ml.primarySectionLists">
+      {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
+    </div>
+    <!-- otherwise show the primary section -->
+    <div ng-if="ml.primarySectionLists.length == 1" ng-repeat="list in ml.primarySectionLists">
+      {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
+    </div>
+    <!-- end show combined mailing list or single primary list -->
+    <hr width="98%">
+
+
+    <div ng-show="!ml.hasPrimarySections()" class="col-md-12">
       <p>
         There was an error retrieving the class mailing list for this course.
         Please contact your local academic support staff for assistance.
       </p>
     </div>
-    <div ng-show="ml.hasOtherSections()">
-      <h2><strong>Sections:</strong></h2>
-        <p class="caption">
-          These sections are created in the Manage Sections tool (if installed in your account) or are being sent from the Registrar's Office. Any changes made to those sections will be reflected within these lists.
-        </p>
-        <div class="content-section" ng-repeat="list in ml.otherSectionLists">
-          {% include "mailing_list/_mailing_list_details.html" with scope="section" %}
+
+    <div class="btn-group col-md-12">
+
+      <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+
+        <div class="panel panel-default" ng-show="ml.primarySectionLists.length > 1">
+
+          <div class="panel-heading" role="tab" id="headingOne">
+            <h4 class="panel-title">
+              {% verbatim %}
+              <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+                      Official Course Sections for {{ml.course_code}}
+              </a>
+              {% endverbatim %}
+             </h4>
+          </div>
+
+          <div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+            <div class="panel-body">
+              <div class="col-md-12">
+                <h2>Official Course Sections</h2>
+                <p class="caption">
+                    Click these links to email the enrollees from individual schools.
+                </p>
+              </div>
+              <div  ng-repeat="list in ml.primarySectionLists" ng-if="list.section_id > 0">
+                {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
+              </div>
+            </div>
+          </div>
         </div>
+
+        <div class="panel panel-default" ng-show="ml.otherSectionLists.length > 0">
+          <div class="panel-heading" role="tab" id="headingOne">
+            <h4 class="panel-title">
+              {% verbatim %}
+              <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+                <ng-pluralize count="ml.otherSectionLists.length" when="{'0': 'No Sections for ', 'one': '1 Section for ', 'other': '{} Sections for '}"></ng-pluralize>{{ml.course_code}}
+              </a>
+              {% endverbatim %}
+             </h4>
+          </div>
+          <div id="collapseTwo" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
+            <div class="panel-body">
+              <div class="col-md-12">
+                <h2>Sections</h2>
+                <p class="caption">
+                    These sections are created in the Manage Sections tool (if installed in your account) or are being sent from the Registrar's Office. Any changes made to those sections will be reflected within these lists.
+                </p>
+              </div>
+              <div class="content-section" ng-repeat="list in ml.otherSectionLists">
+                {% include "mailing_list/_mailing_list_details.html" with scope="section" %}
+              </div>
+            </div>
+          </div>
+        </div>
+
+      </div>
     </div>
+
   </main>
 </body>
 {% endblock body %}
+

--- a/mailing_list/templates/mailing_list/admin_index.html
+++ b/mailing_list/templates/mailing_list/admin_index.html
@@ -21,143 +21,156 @@ $(document).ready(function(){
       role="application"
       ng-controller="MailingListController as ml">
 
-  <header>
-    <div class="row lti-header">
-      <h1>
-        {% block breadcrumbs %}Course Emailer{% endblock breadcrumbs %}
-      </h1>
-    </div>
-  </header>
-
-  <div class="loading-indicator" ng-show="ml.isLoading">
-    <img src="{% static 'images/ajax-loader-large.gif' %}"/>
-  </div>
-
-  <main class="ng-hide" ng-show="ml.loaded">
-
-    <div ng-show="ml.hasPrimarySections()" class="col-md-12">
-      {% verbatim %}
-      <h2>Mailing List for {{ml.course_code}}</h2>
-      {% endverbatim %}
-      <p class="caption">
-        The mailing list contains staff, students, and guests who have been added to this course.
-        <a target="_blank"
-           href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer "
-           class="lti-tooltip"
-           rel="tooltip"
-           data-toggle="tooltip"
-           title=""
-           data-original-title="More info about the Course Emailer"><i class="fa fa-question-circle"></i></a>
-        <div ng-show="ml.hasPrimarySections()">
-          This course site includes enrollment from two or more schools.
-          <a target="_blank"
-             href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer"
-             class="lti-tooltip"
-             rel="tooltip"
-             data-toggle="tooltip"
-             title=""
-             data-original-title="More info about cross listed courses"><i class="fa fa-question-circle"></i></a>
+<div class="container">
+    <header>
+        <div class="row lti-header">
+            <h1>
+                {% block breadcrumbs %}Course Emailer{% endblock breadcrumbs %}
+            </h1>
         </div>
-      </p>
+    </header>
+
+    <div class="loading-indicator" ng-show="ml.isLoading">
+        <img src="{% static 'images/ajax-loader-large.gif' %}"/>
     </div>
 
-    <hr width="98%">
-    <!-- show combined mailing list or single primary list -->
-    <!-- if there is a combined mailing list show it -->
-    <div ng-if="ml.primarySectionLists.length > 1 && list.section_id == 0"
-         ng-repeat="list in ml.primarySectionLists">
-      {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
-    </div>
-    <!-- otherwise show the primary section -->
-    <div ng-if="ml.primarySectionLists.length == 1" ng-repeat="list in ml.primarySectionLists">
-      {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
-    </div>
-    <!-- end show combined mailing list or single primary list -->
-    <hr width="98%">
+    <main class="ng-hide" ng-show="ml.loaded">
 
-
-    <div ng-show="!ml.hasPrimarySections()" class="col-md-12">
-      <p>
-        There was an error retrieving the class mailing list for this course.
-        Please contact your local academic support staff for assistance.
-      </p>
-    </div>
-
-    <div class="btn-group col-md-12">
-      <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
-        <div class="panel panel-default" ng-show="ml.primarySectionLists.length > 1">
-          <div class="panel-heading" role="tab" id="headingOne">
-            <h4 class="panel-title">
-              {% verbatim %}
-              <a class="collapsed"
-                 role="button"
-                 data-toggle="collapse"
-                 data-parent="#accordion"
-                 href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
-                      Official Course Sections for {{ml.course_code}}
-              </a>
-              {% endverbatim %}
-             </h4>
-          </div>
-
-          <div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
-            <div class="panel-body">
-              <div class="col-md-12">
-                <h2>Official Course Sections</h2>
-                <p class="caption">
-                    These mailing lists contains staff, students, and guests from individual schools.
-                </p>
+        <div ng-show="ml.hasPrimarySections()" class="col-md-12">
+        {% verbatim %}
+          <h2>Mailing List for {{ml.course_code}}</h2>
+        {% endverbatim %}
+            <p class="caption">
+                The mailing list contains staff, students, and guests who have been added to this course.
+                <a target="_blank"
+                   href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer "
+                   class="lti-tooltip"
+                   rel="tooltip"
+                   data-toggle="tooltip"
+                   title=""
+                   data-original-title="More info about the Course Emailer">
+                    <i class="fa fa-question-circle"></i>
+                </a>
+                <div ng-show="ml.hasPrimarySections()">
+                    This course site includes enrollment from two or more schools.
+                    <a target="_blank"
+                       href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer"
+                       class="lti-tooltip"
+                       rel="tooltip"
+                       data-toggle="tooltip"
+                       title=""
+                       data-original-title="More info about cross listed courses">
+                        <i class="fa fa-question-circle"></i>
+                  </a>
               </div>
-              <div  ng-repeat="list in ml.primarySectionLists" ng-if="list.section_id > 0">
-                {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
-              </div>
+          </p>
+        </div>
+
+        <div class="col-md-12">
+            <!--<hr width="98%">-->
+            <!-- show combined mailing list or single primary list -->
+            <!-- if there is a combined mailing list show it -->
+            <div ng-if="ml.hasPrimarySections() && ml.isCourseList(list)"
+               ng-repeat="list in ml.primarySectionLists">
+              {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
+                <div class="col-md-12">
+                    <hr width="98%">
+                </div>
             </div>
-          </div>
-        </div>
 
-        <div class="panel panel-default" ng-show="ml.otherSectionLists.length > 0">
-          <div class="panel-heading" role="tab" id="headingOne">
-            <h4 class="panel-title">
-              {% verbatim %}
-              <a class="collapsed"
-                 role="button"
-                 data-toggle="collapse"
-                 data-parent="#accordion"
-                 href="#collapseTwo"
-                 aria-expanded="false" aria-controls="collapseTwo">
-                <ng-pluralize count="ml.otherSectionLists.length"
-                              when="{'0': 'No Sections for ', 'one': '1 Section for ', 'other': '{} Sections for '}">
-                </ng-pluralize>{{ml.course_code}}
-              </a>
-              {% endverbatim %}
-             </h4>
-          </div>
-          <div id="collapseTwo" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
-            <div class="panel-body">
-              <div class="col-md-12">
-                <h2>Sections</h2>
-                <p class="caption">
-                  If you would like a copy of your email, add your own email address to the CC or BCC field.
-                  Any email sent to a section will be delivered to all staff in the course, even if they have
-                  not been added to the section.
-                </p>
-                <p class="caption">
-                  These sections are created in the Manage Sections tool (if installed in your account) or are being
-                  sent from the Registrar's Office. Any changes made to those sections will be reflected
-                  within these lists.
-                </p>
-              </div>
-              <div class="content-section" ng-repeat="list in ml.otherSectionLists">
-                {% include "mailing_list/_mailing_list_details.html" with scope="section" %}
-              </div>
+            <!-- otherwise show the primary section -->
+            <div ng-if="ml.primarySectionLists.length == 1" ng-repeat="list in ml.primarySectionLists">
+              {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
             </div>
-          </div>
-        </div>
+            <!-- end show combined mailing list or single primary list -->
 
-      </div>
-    </div>
+            <div ng-show="!ml.hasPrimarySections()" class="col-md-12">
+              <p>
+                  There was an error retrieving the class mailing list for this course.
+                  Please contact your local academic support staff for assistance.
+              </p>
+            </div>
 
-  </main>
+            <div class="btn-group col-md-12">
+              <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+                  <div class="panel panel-default" ng-show="ml.hasPrimarySections()">
+                      <div class="panel-heading" role="tab" id="headingOne">
+                          <h4 class="panel-title">
+                              {% verbatim %}
+                              <a class="collapsed"
+                                 role="button"
+                                 data-toggle="collapse"
+                                 data-parent="#accordion"
+                                 href="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+                                  Official Course Sections for {{ml.course_code}}
+                              </a>
+                              {% endverbatim %}
+                          </h4>
+                      </div>
+
+                      <div id="collapseOne" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingOne">
+                          <div class="panel-body">
+                              <div class="col-md-12">
+                                  <h2>Official Course Sections</h2>
+                                  <p class="caption">
+                                      These mailing lists contains staff, students, and guests from individual schools.
+                                  </p>
+                              </div>
+
+                              <div  ng-repeat="list in ml.primarySectionLists" ng-if="!ml.isCourseList(list)">
+                                  {% include "mailing_list/_mailing_list_details.html" with scope="class" %}
+                              </div>
+
+                          </div>
+                      </div>
+                  </div>
+
+                  <div class="panel panel-default" ng-show="ml.hasOtherSections">
+                      <div class="panel-heading" role="tab" id="headingOne">
+                          <h4 class="panel-title">
+                              {% verbatim %}
+                              <a class="collapsed"
+                                 role="button"
+                                 data-toggle="collapse"
+                                 data-parent="#accordion"
+                                 href="#collapseTwo"
+                                 aria-expanded="false" aria-controls="collapseTwo">
+                                  <ng-pluralize count="ml.otherSectionLists.length"
+                                                when="{'0': 'No Sections for ', 'one': '1 Section for ', 'other': '{} Sections for '}">
+
+                                  </ng-pluralize>{{ml.course_code}}
+                              </a>
+                              {% endverbatim %}
+                          </h4>
+                      </div>
+
+                      <div id="collapseTwo" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
+                          <div class="panel-body">
+                              <div class="col-md-12">
+                                  <h2>Sections</h2>
+                                  <p class="caption">
+                                      If you would like a copy of your email, add your own email address to the CC or BCC field.
+                                      Any email sent to a section will be delivered to all staff in the course, even if they have
+                                      not been added to the section.
+                                  </p>
+                                  <p class="caption">
+                                      These sections are created in the Manage Sections tool (if installed in your account) or are being
+                                      sent from the Registrar's Office. Any changes made to those sections will be reflected
+                                      within these lists.
+                                  </p>
+                              </div>
+                              <div class="content-section" ng-repeat="list in ml.otherSectionLists">
+                                  {% include "mailing_list/_mailing_list_details.html" with scope="section" %}
+                              </div>
+                          </div>
+                      </div>
+                  </div> <!-- end panel     -->
+              </div> <!-- end panel group -->
+            </div> <!-- end btn group     -->
+        </div> <!-- end col-md-12     -->
+    </main>
+</div>
+
 </body>
 {% endblock body %}
 

--- a/mailing_list/templates/mailing_list/base.html
+++ b/mailing_list/templates/mailing_list/base.html
@@ -7,10 +7,7 @@
     <link href="{% static 'favicon.ico' %}" rel="icon" type="image/x-icon">
     <link rel="stylesheet" type="text/css" href="{% static 'lti-css/tooltipModal.css' %}" media="screen"/>
     <link rel="stylesheet" type="text/css" href="{% static 'font-awesome-4.2.0/css/font-awesome.min.css' %}" media="screen"/>
-
-    <!--<link rel="stylesheet" type="text/css" href="{% static 'lti-css/listserv.css' %}" media="screen"/>-->
     <link rel="stylesheet" type="text/css" href="{% static 'harvard-bootstrap/css/harvard-bootstrap.css' %}" media="screen"/>
-
     {% block css %}{% endblock css %}
     <script src="{% static 'jquery-1.10.2/jquery-1.10.2.min.js' %}"></script>
     <script src="{% static 'underscore-1.8.2/underscore.min.js' %}"></script>

--- a/mailing_list/templates/mailing_list/base.html
+++ b/mailing_list/templates/mailing_list/base.html
@@ -7,11 +7,14 @@
     <link href="{% static 'favicon.ico' %}" rel="icon" type="image/x-icon">
     <link rel="stylesheet" type="text/css" href="{% static 'lti-css/tooltipModal.css' %}" media="screen"/>
     <link rel="stylesheet" type="text/css" href="{% static 'font-awesome-4.2.0/css/font-awesome.min.css' %}" media="screen"/>
-    <link rel="stylesheet" type="text/css" href="{% static 'lti-css/listserv.css' %}" media="screen"/>
+
+    <!--<link rel="stylesheet" type="text/css" href="{% static 'lti-css/listserv.css' %}" media="screen"/>-->
+    <link rel="stylesheet" type="text/css" href="{% static 'harvard-bootstrap/css/harvard-bootstrap.css' %}" media="screen"/>
+
     {% block css %}{% endblock css %}
     <script src="{% static 'jquery-1.10.2/jquery-1.10.2.min.js' %}"></script>
     <script src="{% static 'underscore-1.8.2/underscore.min.js' %}"></script>
-    <script src="{% static 'js/tooltipModal.js' %}"></script>
+    <script src="{% static 'bootstrap-3.0.3/dist/js/bootstrap.min.js' %}"></script>
     <script src="{% static 'angular-1.3.9/angular.min.js' %}"></script>
     <script src="{% static 'angular-1.3.9/angular-sanitize.min.js' %}"></script>
     <script src="{% static 'angular-1.3.9/angular-animate.min.js' %}"></script>

--- a/mailing_list/tests.py
+++ b/mailing_list/tests.py
@@ -14,11 +14,11 @@ class MailingListModelTests(TestCase):
 
     def setUp(self):
         self.sections = [{
-            'id': 1582,
+            'id': '1582',
             'name': 'section name 1',
             'sis_section_id': 334562
         }, {
-            'id': 1583,
+            'id': '1583',
             'name': 'section name 2',
             'sis_section_id': None
         }]
@@ -31,19 +31,19 @@ class MailingListModelTests(TestCase):
         mock_get_enrollments.return_value = []
 
         result = MailingList.objects.get_or_create_or_delete_mailing_lists_for_canvas_course_id(3716)
-        address_1 = settings.LISTSERV_ADDRESS_FORMAT.format(
+        address_1 = settings.LISTSERV_SECTION_ADDRESS_FORMAT.format(
             canvas_course_id=3716,
-            section_id=1582
+            section_id='1582'
         )
-        address_2 = settings.LISTSERV_ADDRESS_FORMAT.format(
+        address_2 = settings.LISTSERV_SECTION_ADDRESS_FORMAT.format(
             canvas_course_id=3716,
-            section_id=1583
+            section_id='1583'
         )
 
         self.assertEqual(result, [{
             'id': 1,
             'canvas_course_id': 3716,
-            'section_id': 1582,
+            'section_id': '1582',
             'name': 'section name 1',
             'address': address_1,
             'access_level': 'members',
@@ -52,7 +52,7 @@ class MailingListModelTests(TestCase):
         }, {
             'id': 2,
             'canvas_course_id': 3716,
-            'section_id': 1583,
+            'section_id': '1583',
             'name': 'section name 2',
             'address': address_2,
             'access_level': 'members',
@@ -66,7 +66,7 @@ class MailingListModelTests(TestCase):
                                                                                       mock_get_enrollments):
         sections = list(self.sections)
         sections.append({
-            'id': 1584,
+            'id': '1584',
             'name': 'section name 3',
             'sis_section_id': None
         })
@@ -74,23 +74,23 @@ class MailingListModelTests(TestCase):
         mock_get_enrollments.return_value = []
 
         result = MailingList.objects.get_or_create_or_delete_mailing_lists_for_canvas_course_id(3716)
-        address_1 = settings.LISTSERV_ADDRESS_FORMAT.format(
+        address_1 = settings.LISTSERV_SECTION_ADDRESS_FORMAT.format(
             canvas_course_id=3716,
-            section_id=1582
+            section_id='1582'
         )
-        address_2 = settings.LISTSERV_ADDRESS_FORMAT.format(
+        address_2 = settings.LISTSERV_SECTION_ADDRESS_FORMAT.format(
             canvas_course_id=3716,
-            section_id=1583
+            section_id='1583'
         )
-        address_3 = settings.LISTSERV_ADDRESS_FORMAT.format(
+        address_3 = settings.LISTSERV_SECTION_ADDRESS_FORMAT.format(
             canvas_course_id=3716,
-            section_id=1584
+            section_id='1584'
         )
 
         self.assertEqual([{
             'id': 1,
             'canvas_course_id': 3716,
-            'section_id': 1582,
+            'section_id': '1582',
             'name': 'section name 1',
             'address': address_1,
             'access_level': 'members',
@@ -99,7 +99,7 @@ class MailingListModelTests(TestCase):
         }, {
             'id': 2,
             'canvas_course_id': 3716,
-            'section_id': 1583,
+            'section_id': '1583',
             'name': 'section name 2',
             'address': address_2,
             'access_level': 'members',
@@ -108,7 +108,7 @@ class MailingListModelTests(TestCase):
         }, {
             'id': 3,
             'canvas_course_id': 3716,
-            'section_id': 1584,
+            'section_id': '1584',
             'name': 'section name 3',
             'address': address_3,
             'access_level': 'members',
@@ -126,18 +126,62 @@ class MailingListModelTests(TestCase):
         mock_get_enrollments.return_value = []
 
         result = MailingList.objects.get_or_create_or_delete_mailing_lists_for_canvas_course_id(3716)
-        address_1 = settings.LISTSERV_ADDRESS_FORMAT.format(
+        address_1 = settings.LISTSERV_SECTION_ADDRESS_FORMAT.format(
             canvas_course_id=3716,
-            section_id=1582
+            section_id='1582'
         )
 
         self.assertEqual([{
             'id': 1,
             'canvas_course_id': 3716,
-            'section_id': 1582,
+            'section_id': '1582',
             'name': 'section name 1',
             'address': address_1,
             'access_level': 'members',
             'members_count': 0,
             'is_primary_section': True
         }], result)
+
+    @patch('mailing_list.models.canvas_api_client.get_course')
+    @patch('mailing_list.models.canvas_api_client.get_enrollments')
+    @patch('mailing_list.models.canvas_api_client.get_sections')
+    def test_get_or_create_or_delete_mailing_lists_for_canvas_course_id_with_multiple_primary_sections(self,
+                                                                                                       mock_get_sections,
+                                                                                                       mock_get_enrollments,
+                                                                                                       mock_get_course):
+        """
+        Test that a new mailing list is created when the course has multiple primary sections. The address of this new list
+        should contain only the course id and the newly created list should have a section id of 'None'.
+        """
+        sections = list(self.sections)
+        mock_get_course.return_value = {
+            'course_code' : 'Test Course',
+        }
+
+        mock_get_sections.return_value = sections
+
+        # append a second primary section
+        sections.append({
+            'id': '1585',
+            'name': 'section name 4',
+            'sis_section_id': 123456
+        })
+
+        mock_get_enrollments.return_value = []
+        result = MailingList.objects.get_or_create_or_delete_mailing_lists_for_canvas_course_id(3716)
+
+        # address of the course list should be set in new mailing list
+        list_address = settings.LISTSERV_COURSE_ADDRESS_FORMAT.format(
+            canvas_course_id=3716,
+        )
+
+        self.assertEqual({
+            'id': 4,
+            'canvas_course_id': 3716,
+            'section_id': 'None',
+            'name': 'Test Course',
+            'address': list_address,
+            'access_level': 'members',
+            'members_count': 0,
+            'is_primary_section': True
+        }, result[-1])

--- a/mailing_list/tests.py
+++ b/mailing_list/tests.py
@@ -142,17 +142,22 @@ class MailingListModelTests(TestCase):
             'is_primary_section': True
         }], result)
 
+    @patch('mailing_list.models.MailingList.objects.get')
     @patch('mailing_list.models.canvas_api_client.get_course')
     @patch('mailing_list.models.canvas_api_client.get_enrollments')
     @patch('mailing_list.models.canvas_api_client.get_sections')
     def test_get_or_create_or_delete_mailing_lists_for_canvas_course_id_with_multiple_primary_sections(self,
                                                                                                        mock_get_sections,
                                                                                                        mock_get_enrollments,
-                                                                                                       mock_get_course):
+                                                                                                       mock_get_course,
+                                                                                                       mock_get_mailinglist):
         """
         Test that a new mailing list is created when the course has multiple primary sections. The address of this new list
         should contain only the course id and the newly created list should have a section id of 'None'.
         """
+
+        mock_get_mailinglist.side_effect = MailingList.DoesNotExist
+
         sections = list(self.sections)
         mock_get_course.return_value = {
             'course_code' : 'Test Course',

--- a/mailing_list/tests.py
+++ b/mailing_list/tests.py
@@ -14,11 +14,11 @@ class MailingListModelTests(TestCase):
 
     def setUp(self):
         self.sections = [{
-            'id': '1582',
+            'id': 1582,
             'name': 'section name 1',
             'sis_section_id': 334562
         }, {
-            'id': '1583',
+            'id': 1583,
             'name': 'section name 2',
             'sis_section_id': None
         }]
@@ -33,17 +33,17 @@ class MailingListModelTests(TestCase):
         result = MailingList.objects.get_or_create_or_delete_mailing_lists_for_canvas_course_id(3716)
         address_1 = settings.LISTSERV_SECTION_ADDRESS_FORMAT.format(
             canvas_course_id=3716,
-            section_id='1582'
+            section_id=1582
         )
         address_2 = settings.LISTSERV_SECTION_ADDRESS_FORMAT.format(
             canvas_course_id=3716,
-            section_id='1583'
+            section_id=1583
         )
 
         self.assertEqual(result, [{
             'id': 1,
             'canvas_course_id': 3716,
-            'section_id': '1582',
+            'section_id': 1582,
             'name': 'section name 1',
             'address': address_1,
             'access_level': 'members',
@@ -52,7 +52,7 @@ class MailingListModelTests(TestCase):
         }, {
             'id': 2,
             'canvas_course_id': 3716,
-            'section_id': '1583',
+            'section_id': 1583,
             'name': 'section name 2',
             'address': address_2,
             'access_level': 'members',
@@ -66,7 +66,7 @@ class MailingListModelTests(TestCase):
                                                                                       mock_get_enrollments):
         sections = list(self.sections)
         sections.append({
-            'id': '1584',
+            'id': 1584,
             'name': 'section name 3',
             'sis_section_id': None
         })
@@ -90,7 +90,7 @@ class MailingListModelTests(TestCase):
         self.assertEqual([{
             'id': 1,
             'canvas_course_id': 3716,
-            'section_id': '1582',
+            'section_id': 1582,
             'name': 'section name 1',
             'address': address_1,
             'access_level': 'members',
@@ -99,7 +99,7 @@ class MailingListModelTests(TestCase):
         }, {
             'id': 2,
             'canvas_course_id': 3716,
-            'section_id': '1583',
+            'section_id': 1583,
             'name': 'section name 2',
             'address': address_2,
             'access_level': 'members',
@@ -108,7 +108,7 @@ class MailingListModelTests(TestCase):
         }, {
             'id': 3,
             'canvas_course_id': 3716,
-            'section_id': '1584',
+            'section_id': 1584,
             'name': 'section name 3',
             'address': address_3,
             'access_level': 'members',
@@ -134,7 +134,7 @@ class MailingListModelTests(TestCase):
         self.assertEqual([{
             'id': 1,
             'canvas_course_id': 3716,
-            'section_id': '1582',
+            'section_id': 1582,
             'name': 'section name 1',
             'address': address_1,
             'access_level': 'members',
@@ -162,8 +162,8 @@ class MailingListModelTests(TestCase):
 
         # append a second primary section
         sections.append({
-            'id': '1585',
-            'name': 'section name 4',
+            'id': None,
+            'name': 'Test Course',
             'sis_section_id': 123456
         })
 
@@ -178,10 +178,12 @@ class MailingListModelTests(TestCase):
         self.assertEqual({
             'id': 4,
             'canvas_course_id': 3716,
-            'section_id': 'None',
+            'section_id': None,
             'name': 'Test Course',
             'address': list_address,
             'access_level': 'members',
             'members_count': 0,
             'is_primary_section': True
         }, result[-1])
+
+

--- a/mailing_list/urls.py
+++ b/mailing_list/urls.py
@@ -5,8 +5,8 @@ from mailing_list import views, api
 
 urlpatterns = [
     url(r'^admin_index$', views.admin_index, name='admin_index'),
-    url(r'^list_members/(?P<section_id>\w+)$', views.list_members, name='list_members'),
+    url(r'^list_members/$', views.list_members, name='list_members_no_id'),
+    url(r'^list_members/(?P<section_id>\d+)$', views.list_members, name='list_members'),
     url(r'^api/lists$', api.lists, name='api_lists'),
-    url(r'^api/course$', api.get_course, name='api_course'),
     url(r'^api/lists/(?P<mailing_list_id>\d+)/set_access_level$', api.set_access_level, name='api_lists_set_access_level'),
 ]

--- a/mailing_list/urls.py
+++ b/mailing_list/urls.py
@@ -5,10 +5,8 @@ from mailing_list import views, api
 
 urlpatterns = [
     url(r'^admin_index$', views.admin_index, name='admin_index'),
-    url(r'^list_members/(?P<section_id>\d+)$', views.list_members,
-        name='list_members'),
+    url(r'^list_members/(?P<section_id>\w+)$', views.list_members, name='list_members'),
     url(r'^api/lists$', api.lists, name='api_lists'),
     url(r'^api/course$', api.get_course, name='api_course'),
-    url(r'^api/lists/(?P<mailing_list_id>\d+)/set_access_level$',
-        api.set_access_level, name='api_lists_set_access_level'),
+    url(r'^api/lists/(?P<mailing_list_id>\d+)/set_access_level$', api.set_access_level, name='api_lists_set_access_level'),
 ]

--- a/mailing_list/urls.py
+++ b/mailing_list/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     url(r'^list_members/(?P<section_id>\d+)$', views.list_members,
         name='list_members'),
     url(r'^api/lists$', api.lists, name='api_lists'),
+    url(r'^api/course$', api.get_course, name='api_course'),
     url(r'^api/lists/(?P<mailing_list_id>\d+)/set_access_level$',
         api.set_access_level, name='api_lists_set_access_level'),
 ]


### PR DESCRIPTION
Jira ticket: https://jira.huit.harvard.edu/browse/TLT-1885

1) Create new mailing list for courses with multiple primary sections:

This PR has code that checks to see if the course has multiple primary sections. If this is true, it creates a new mailing list (in the postgres db for the mailer only) to be a master list which includes all the enrollments for the course. The meat of this change is in the mailing_list.model file and the subsequent migration to modify the section id field. Changing the field type from int to char resulted in many little code changes to accommodate the new type. 

The email address of the new address is different that the other section addresses. it only contains the 
course id (canvas-{canvas_course_id}@) vs (canvas-{canvas_course_id}-{section_id}@)

2) UI enhancements:

This PR also contains UI changes. See the wiki page for more info, mock ups and text:
https://wiki.harvard.edu/confluence/pages/viewpage.action?title=Course+Emailer+-+TLT-1885&spaceKey=UIS

includes modifications to angular and templates

3) Other changes/updates:

fixed unit tests and added new test. All tests run.

This commit also exposes port 5432 in Vagrant which allows us to access the postgres database with apps like Portico.

Testing:

I have tested this code with both courses that have multiple primary sections, courses with one primary section, and a course with no primary sections. 
Here are the courses I used for testing:
https://canvas.icommons.harvard.edu/courses/5980/external_tools/1685
https://canvas.icommons.harvard.edu/courses/6020/external_tools/1684
https://canvas.icommons.harvard.edu/courses/5958/external_tools/1685

