### PR TITLE
Sprint 31 TLT-1949 Increment django_auth_lti version

### DIFF
--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -12,4 +12,4 @@ ndg-httpsclient==0.4.0
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.8.1#egg=canvas-python-sdk==0.8.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.5#egg=django-icommons-common==1.10.5
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8
-git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.2#egg=django-auth-lti==1.2.2
+git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.4#egg=django-auth-lti==1.2.4


### PR DESCRIPTION
We need the the `custom_canvas_membership_roles` param from the LTI launch.