### PR TITLE
Sprint 31 TLT-2006 Cleanly handle emails with attachments and no html body

### DIFF
--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -42,8 +42,8 @@ def handle_mailing_list_email_route(request):
     sender = request.POST.get('sender')
     recipient = request.POST.get('recipient')
     subject = request.POST.get('subject')
-    body_plain = request.POST.get('body-plain')
-    body_html = request.POST.get('body-html')
+    body_plain = request.POST.get('body-plain', '')
+    body_html = request.POST.get('body-html', '')
     to_list = address.parse_list(request.POST.get('To'))
     cc_list = address.parse_list(request.POST.get('Cc'))
 

--- a/mailgun/tests.py
+++ b/mailgun/tests.py
@@ -1,18 +1,84 @@
 import hashlib
 import hmac
+import json
 import time
 import uuid
+from StringIO import StringIO
 
 from django.conf import settings
-from django.test.utils import override_settings
-from django.test import TestCase
+from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse_lazy
+from django.test import TestCase, RequestFactory
+from django.test.utils import override_settings
 
-from mock import patch, MagicMock
+from mock import MagicMock, patch
 
 from icommons_common.utils import Bunch
 
 from .decorators import authenticate
+from .route_handlers import handle_mailing_list_email_route
+
+
+class RouteHandlerRegressionTests(TestCase):
+    longMessage = True
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(username='unittest',
+                                             email='unittest@example.edu',
+                                             password='unittest')
+
+    @patch('mailgun.route_handlers.CourseInstance.objects.get')
+    @patch('mailgun.route_handlers.MailingList.objects.get_or_create_or_delete_mailing_list_by_address')
+    def test_empty_body_html(self, mock_ml_get, mock_ci_get):
+        ''' TLT-2006
+        Verifies that we can handle emails that
+        * have at least one inlined attachment
+        * do not have an html body
+        '''
+        # prep an attachment object (attributes added to match what
+        # django.test.client.encode_file() looks for)
+        attachment_fp = StringIO('lorem ipsum')
+        attachment_fp.name = 'lorem.txt'
+        attachment_fp.content_type = 'text/plain'
+
+        # prep a MailingList mock
+        members = [{'address': a} for a in
+                       ['unittest@example.edu', 'student@example.edu']]
+        ml = MagicMock(
+                canvas_course_id=123,
+                section_id=456,
+                teaching_staff_addresses={'teacher@example.edu'},
+                members=members,
+                address='class-list@example.edu')
+        mock_ml_get.return_value = ml
+
+        # prep a CourseInstance mock
+        ci = MagicMock(course_instance_id=789,
+                       canvas_course_id=ml.canvas_course_id,
+                       short_title='Lorem For Beginners')
+        mock_ci_get.return_value = ci
+
+        # prep the post body
+        post_body = {
+            'sender': 'Unit Test <unittest@example.edu>',
+            'recipient': ml.address,
+            'subject': 'blah',
+            'body-plain': 'blah [cid:{}] blah'.format(attachment_fp.name),
+            'To': ml.address,
+            'attachment-count': 1,
+            'attachment-1': attachment_fp,
+            'content-id-map': json.dumps({attachment_fp.name: 'attachment-1'}),
+        }
+        post_body.update(generate_signature_dict())
+
+        # prep the request
+        request = self.factory.post('/', post_body)
+        request.user = self.user
+
+        # run the view, verify success
+        response = handle_mailing_list_email_route(request)
+        self.assertEqual(response.status_code, 200)
 
 
 @override_settings(LISTSERV_API_KEY=str(uuid.uuid4()))
@@ -20,18 +86,7 @@ class DecoratorTests(TestCase):
     longMessage = True
 
     def setUp(self):
-        timestamp = str(time.time())
-        token = str(uuid.uuid4())
-        signature = hmac.new(
-            key=settings.LISTSERV_API_KEY,
-            msg='{}{}'.format(timestamp, token),
-            digestmod=hashlib.sha256
-        ).hexdigest()
-        self.POST = {
-            'timestamp': timestamp,
-            'token': token,
-            'signature': signature
-        }
+        self.POST = generate_signature_dict()
 
     def test_authenticate_success(self):
         request = Bunch(
@@ -105,3 +160,18 @@ class DecoratorTests(TestCase):
             'token': self.POST['token'],
             'signature': 'FFFF'
         })
+
+
+def generate_signature_dict():
+    timestamp = str(time.time())
+    token = str(uuid.uuid4())
+    signature = hmac.new(
+        key=settings.LISTSERV_API_KEY,
+        msg='{}{}'.format(timestamp, token),
+        digestmod=hashlib.sha256
+    ).hexdigest()
+    return {
+        'timestamp': timestamp,
+        'token': token,
+        'signature': signature
+    }


### PR DESCRIPTION
The logic to correct the content id in the email body assumed we were receiving both html and plaintext formatted bodies.  When that wasn't the case, we tried to `re.sub()` `None`, which throws a `TypeError`.  Let's make sure we're always working with strings for the body variables.