### PR TITLE
Sprint 32 TLT-2014 Add a new command to dump emails sent through lti_emailer

### DIFF
--- a/mailgun/management/commands/_mailgun_api.py
+++ b/mailgun/management/commands/_mailgun_api.py
@@ -1,0 +1,42 @@
+import datetime
+import logging
+import requests
+
+from django.conf import settings
+
+
+DATE_FORMAT = '%a, %d %b %Y %H:%M:%S %z'
+EVENTS_MAX_PAGE_SIZE = 300
+
+logger = logging.getLogger(__name__)
+
+
+def get_events(begin, end, event_types):
+    # prime the pump
+    url = '{}{}/events'.format(settings.LISTSERV_API_URL,
+                               settings.LISTSERV_DOMAIN)
+    auth = (settings.LISTSERV_API_USER, settings.LISTSERV_API_KEY)
+    params = {
+        'begin': begin.strftime(DATE_FORMAT),
+        'end': end.strftime(DATE_FORMAT),
+        'limit': EVENTS_MAX_PAGE_SIZE,
+        'event': ' OR '.join(event_types),
+    }
+    resp = requests.get(url, auth=auth, params=params)
+    resp.raise_for_status()
+    events = resp.json()['items']
+
+    # follow 'next' links until we get a blank page
+    while True:
+        url = resp.json()['paging']['next']
+        try:
+            resp = requests.get(url, auth=auth)
+            resp.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            raise CommandError(str(e))
+        page = resp.json()['items']
+        if len(page) == 0:
+            break
+        else:
+            events.extend(page)
+    return events

--- a/mailgun/management/commands/mailgun_delivery_times.py
+++ b/mailgun/management/commands/mailgun_delivery_times.py
@@ -1,4 +1,3 @@
-import argparse
 import datetime
 import logging
 import requests
@@ -8,9 +7,9 @@ import pytz
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
+from mailgun.management.commands._mailgun_api import get_events
 
-DATE_FORMAT = '%a, %d %b %Y %H:%M:%S %z'
-EVENTS_MAX_PAGE_SIZE = 300
+
 EVENTS_OF_INTEREST = ('accepted', 'delivered')
 
 logger = logging.getLogger(__name__)
@@ -30,42 +29,12 @@ class Command(BaseCommand):
         begin = end - datetime.timedelta(days=options['days_back'])
         logger.info('Pulling {} days of events for {}'.format(
                         options['days_back'], settings.LISTSERV_DOMAIN))
-        events = self.get_events(begin, end)
+        try:
+            events = get_events(begin, end, EVENTS_OF_INTEREST)
+        except RuntimeError as e:
+            raise CommandError(unicode(e))
         logger.debug('Done pulling events')
         self.process_events(events)
-
-    def get_events(self, begin, end):
-        # prime the pump
-        url = '{}{}/events'.format(settings.LISTSERV_API_URL,
-                                   settings.LISTSERV_DOMAIN)
-        auth = (settings.LISTSERV_API_USER, settings.LISTSERV_API_KEY)
-        params = {
-            'begin': begin.strftime(DATE_FORMAT),
-            'end': end.strftime(DATE_FORMAT),
-            'limit': EVENTS_MAX_PAGE_SIZE,
-            'event': ' OR '.join(EVENTS_OF_INTEREST),
-        }
-        try:
-            resp = requests.get(url, auth=auth, params=params)
-            resp.raise_for_status()
-        except requests.exceptions.RequestException as e:
-            raise CommandError(str(e))
-        events = resp.json()['items']
-
-        # follow 'next' links until we get a blank page
-        while True:
-            url = resp.json()['paging']['next']
-            try:
-                resp = requests.get(url, auth=auth)
-                resp.raise_for_status()
-            except requests.exceptions.RequestException as e:
-                raise CommandError(str(e))
-            page = resp.json()['items']
-            if len(page) == 0:
-                break
-            else:
-                events.extend(page)
-        return events
 
     def process_events(self, events):
         times = defaultdict(dict)

--- a/mailgun/management/commands/mailgun_emails_sent.py
+++ b/mailgun/management/commands/mailgun_emails_sent.py
@@ -1,0 +1,79 @@
+import argparse
+import csv
+import datetime
+import logging
+import requests
+import sys
+from collections import defaultdict
+
+import pytz
+from django.core.management.base import BaseCommand, CommandError
+from django.conf import settings
+
+from mailgun.management.commands._mailgun_api import get_events
+
+
+EVENTS_OF_INTEREST = ('accepted',)
+
+logger = logging.getLogger(__name__)
+utc = pytz.timezone('UTC')
+
+
+class Command(BaseCommand):
+    help = '''Prints a list of emails sent in a given time window'''
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--begin-time', type=int, required=True,
+            help='Beginning of the window to look for emails, as unix timestamp')
+        parser.add_argument(
+            '--end-time', type=int, required=True,
+            help='End of the window to look for emails, as unix timestamp')
+        parser.add_argument(
+            '--output-file', type=argparse.FileType('w'), default=sys.stdout,
+            help='File to output the csv of emails sent to, defaults to stdout')
+
+    def handle(self, *args, **options):
+        begin = datetime.datetime.fromtimestamp(options['begin_time'], utc)
+        end = datetime.datetime.fromtimestamp(options['end_time'], utc)
+
+        events = get_events(begin, end, EVENTS_OF_INTEREST)
+        self.process_events(events, options['output_file'])
+
+    def process_events(self, events, output_file):
+        rows = []
+        for event in events:
+            try:
+                sender = event['envelope']['sender']
+            except RuntimeError:
+                logger.exception('event {} missing a sender'.format(event))
+                continue
+
+            if sender.endswith(settings.LISTSERV_DOMAIN):
+                continue
+
+            try:       
+                list_address = None
+                for recipient in event['message']['recipients']:
+                    if (settings.LISTSERV_SECTION_ADDRESS_RE.match(recipient)
+                            or settings.LISTSERV_COURSE_ADDRESS_RE.match(recipient)):
+                        list_address = recipient
+                        break
+
+                row = [
+                    float(event['timestamp']),
+                    list_address,
+                    sender,
+                    event['message']['headers']['subject'],
+                    event['message']['headers']['message-id']
+                ]
+            except KeyError as e:
+                logger.error('Unable to extract {} from event'.format(e.args[0]))
+            else:
+                rows.append(row)
+        rows.sort()
+
+        headers = ('timestamp', 'list', 'sender', 'subject', 'message-id')
+        writer = csv.writer(output_file)
+        writer.writerow(headers)
+        writer.writerows(rows)

--- a/mailgun/management/commands/mailgun_emails_sent.py
+++ b/mailgun/management/commands/mailgun_emails_sent.py
@@ -52,6 +52,7 @@ class Command(BaseCommand):
                 logger.exception('event {} missing a sender'.format(event))
                 continue
 
+            # skip events where we're forwarding mail to the list
             if sender.endswith(settings.LISTSERV_DOMAIN):
                 continue
 


### PR DESCRIPTION
* dumps a csv of all relevant details
* factored the event pull out to a library for use by other commands

Usage:
```
usage: manage.py mailgun_emails_sent [-h] [--version] [-v {0,1,2,3}]
                                     [--settings SETTINGS]
                                     [--pythonpath PYTHONPATH] [--traceback]
                                     [--no-color] --begin-time BEGIN_TIME
                                     --end-time END_TIME
                                     [--output-file OUTPUT_FILE]

Prints a list of emails sent in a given time window

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output,
                        2=verbose output, 3=very verbose output
  --settings SETTINGS   The Python path to a settings module, e.g.
                        "myproject.settings.main". If this isn't provided, the
                        DJANGO_SETTINGS_MODULE environment variable will be
                        used.
  --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g.
                        "/home/djangoprojects/myproject".
  --traceback           Raise on CommandError exceptions
  --no-color            Don't colorize the command output.
  --begin-time BEGIN_TIME
                        Beginning of the window to look for emails, as unix
                        timestamp
  --end-time END_TIME   End of the window to look for emails, as unix
                        timestamp
  --output-file OUTPUT_FILE
                        File to output the csv of emails sent to, defaults to
                        stdout
```

Sample output:
```
(lti_emailer)vagrant@precise64:~/tlt/lti_emailer(task/rascalking/tlt-2014/add-command-to-dump-email-details) $ python manage.py mailgun_emails_sent --begin 1443100620 --end 1442927820
timestamp,list,sender,subject,message-id
1443018234.343599,canvas-6760-2069@mg.dev.tlt.harvard.edu,david_bonner@harvard.edu,text inline test,BLUPR0701MB81737D7BBE335EDEB69AB6BE1440@BLUPR0701MB817.namprd07.prod.outlook.com
1443018236.402548,canvas-6760-2069@mg.dev.tlt.harvard.edu,david_bonner@harvard.edu,text inline test,BLUPR0701MB81737D7BBE335EDEB69AB6BE1440@BLUPR0701MB817.namprd07.prod.outlook.com
1443024438.403159,canvas-6760-2069@mg.dev.tlt.harvard.edu,david_bonner@harvard.edu,test test,BLUPR0701MB8176D5BF8F3656C09487CF8E1440@BLUPR0701MB817.namprd07.prod.outlook.com
1443024440.51515,canvas-6760-2069@mg.dev.tlt.harvard.edu,david_bonner@harvard.edu,test test,BLUPR0701MB8176D5BF8F3656C09487CF8E1440@BLUPR0701MB817.namprd07.prod.outlook.com
1443024634.650738,canvas-6760-2069@mg.dev.tlt.harvard.edu,david_bonner@harvard.edu,test test,SN2PR0701MB83059C1297F5DDFCF1F747CE1440@SN2PR0701MB830.namprd07.prod.outlook.com
1443024636.792531,canvas-6760-2069@mg.dev.tlt.harvard.edu,david_bonner@harvard.edu,test test,SN2PR0701MB83059C1297F5DDFCF1F747CE1440@SN2PR0701MB830.namprd07.prod.outlook.com
1443024701.079242,canvas-6760-2069@mg.dev.tlt.harvard.edu,david_bonner@harvard.edu,test test,SN2PR0701MB82983E1EA28D5D41144BB97E1440@SN2PR0701MB829.namprd07.prod.outlook.com
1443024703.135383,canvas-6760-2069@mg.dev.tlt.harvard.edu,david_bonner@harvard.edu,test test,SN2PR0701MB82983E1EA28D5D41144BB97E1440@SN2PR0701MB829.namprd07.prod.outlook.com
```