### PR TITLE
Sprint 32 TLT-2016 Use unicode format strings for *ALL* logs

### DIFF
--- a/lti_emailer/views.py
+++ b/lti_emailer/views.py
@@ -62,7 +62,7 @@ def tool_config(request):
 @csrf_exempt
 def lti_launch(request):
     logger.debug(
-        "lti_emailer launched with params: %s",
+        u"lti_emailer launched with params: %s",
         json.dumps(request.POST.dict(), indent=4)
     )
     return redirect('mailing_list:admin_index')

--- a/mailgun/decorators.py
+++ b/mailgun/decorators.py
@@ -23,12 +23,12 @@ def authenticate(redirect_url=reverse_lazy('mailgun:auth_error')):
                 token = request.POST['token']
                 signature = request.POST['signature']
             except KeyError as e:
-                logger.error("Received mailgun callback request with missing auth param %s", e.message)
+                logger.error(u"Received mailgun callback request with missing auth param %s", e.message)
                 return redirect(redirect_url)
 
             time_diff = time.time() - float(timestamp)
             if time_diff >= settings.MAILGUN_CALLBACK_TIMEOUT:
-                logger.error("Received stale mailgun callback request, time difference was %d", time_diff)
+                logger.error(u"Received stale mailgun callback request, time difference was %d", time_diff)
                 return redirect(redirect_url)
 
             digest = hmac.new(
@@ -38,7 +38,7 @@ def authenticate(redirect_url=reverse_lazy('mailgun:auth_error')):
             ).hexdigest()
 
             if signature != digest:
-                logger.error("Received invalid mailgun callback request signature %s != digest %s", signature, digest)
+                logger.error(u"Received invalid mailgun callback request signature %s != digest %s", signature, digest)
                 return redirect(redirect_url)
 
             return view_func(request, *args, **kwargs)

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -77,6 +77,8 @@ class MailgunClient(object):
             timer.status_code = response.status_code
 
         if response.status_code != 200:
-            message = "Failed to POST email to Mailgun from %s to %s" % (from_address, to_address)
-            logger.error(message)
+            logger.error(
+                u'Failed to POST email from %s to %s.  Status code was %s, body '
+                u'was %s', from_address, to_address, response.status_code,
+                response.text)
             raise ListservApiError(message)

--- a/mailing_list/api.py
+++ b/mailing_list/api.py
@@ -43,8 +43,9 @@ def lists(request):
         )
 
     except Exception:
-        message = "Failed to get_or_create MailingLists with LTI params %s" % json.dumps(request.LTI)
-        logger.exception(message)
+        logger.exception(
+            u"Failed to get_or_create MailingLists with LTI params %s",
+            json.dumps(request.LTI))
         return create_json_500_response(message)
 
     return create_json_200_response(mailing_lists)
@@ -80,8 +81,9 @@ def set_access_level(request, mailing_list_id):
             'access_level': access_level
         }
     except Exception:
-        message = "Failed to activate MailingList %s with LTI params %s" % (mailing_list_id, json.dumps(request.LTI))
-        logger.exception(message)
+        logger.exception(
+            u"Failed to activate MailingList %s with LTI params %s",
+            mailing_list_id, json.dumps(request.LTI))
         return create_json_500_response(message)
 
     return create_json_200_response(result)

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -229,8 +229,8 @@ class MailingList(models.Model):
     def send_mail(self, sender_display_name, sender_address, to_address,
                   subject='', text='', html='', original_to_address=None,
                   original_cc_address=None, attachments=None, inlines=None):
-        logger.debug("in send_mail: sender_address=%s, to_address=%s, "
-                     "mailing_list.address=%s ",
+        logger.debug(u"in send_mail: sender_address=%s, to_address=%s, "
+                     u"mailing_list.address=%s ",
                      sender_address, to_address, self.address)
         mailing_list_address = addresslib.address.parse(self.address)
         mailing_list_address.display_name = sender_display_name

--- a/mailing_list/views.py
+++ b/mailing_list/views.py
@@ -27,8 +27,8 @@ def admin_index(request):
 
     course_code = get_course(canvas_course_id)['course_code']
 
-    logger.info("Rendering mailing_list admin_index view for user %s"
-                % logged_in_user_id)
+    logger.info(u"Rendering mailing_list admin_index view for user %s",
+                logged_in_user_id)
     return render(request, 'mailing_list/admin_index.html', {'course_code': course_code})
 
 
@@ -43,9 +43,8 @@ def list_members(request, section_id=None):
         return HttpResponseBadRequest('Unable to determine canvas course id')
 
     logger.info(
-        'Rendering mailing_list section_list_details view for canvas course {}, section {}'.format(
-            canvas_course_id, section_id
-        )
+        u'Rendering mailing_list section_list_details view for canvas course %s '
+        u'section %s', canvas_course_id, section_id)
     )
 
     if section_id:

--- a/mailing_list/views.py
+++ b/mailing_list/views.py
@@ -45,7 +45,6 @@ def list_members(request, section_id=None):
     logger.info(
         u'Rendering mailing_list section_list_details view for canvas course %s '
         u'section %s', canvas_course_id, section_id)
-    )
 
     if section_id:
         mailing_list = get_object_or_404(MailingList, canvas_course_id=canvas_course_id, section_id=section_id)


### PR DESCRIPTION
* also, convert all logs to '%s'-style format strings