### PR TITLE
TLT-1920 - updated bounce message text

### DIFF
--- a/mailgun/templates/mailgun/email/bounce_back_access_denied.html
+++ b/mailgun/templates/mailgun/email/bounce_back_access_denied.html
@@ -6,8 +6,8 @@
     <body>
         <h4>***Your message could not be delivered to mailing list {{ recipient }}.***</h4>
         <p>
-            Either you have insufficient permission to email this list, or you didn’t set your current email address as your default address in Canvas.
-            Please contact the teaching staff of this course for assistance.
+        Either you didn’t set your current email address as your default address in Canvas or you have
+            insufficient permission to email this list. Visit the <a href="https://wiki.harvard.edu/confluence/pages/viewpage.action?pageId=190909873">Course Emailer FAQ</a> for help.
         </p>
         <p>------------------------------</p>
         <p><b>From:</b> {{ sender }}</p>


### PR DESCRIPTION
Feedback from the demo was to modify the bounceback. For now, please change text to "Either you didn’t set your current email address as your default address in Canvas or you have insufficient permission to email this list. Visit the Course Emailer FAQ for help. " Course Emailer FAQ link should go to: https://wiki.harvard.edu/confluence/pages/viewpage.action?pageId=190909873 and there is another story in the backlog to have two separate bounceback messages for the 'access denied' errors.