### PR TITLE
Sprint 32 TLT-2029 Add command to print details of failed email sends

### DIFF
--- a/mailgun/management/commands/_mailgun_api.py
+++ b/mailgun/management/commands/_mailgun_api.py
@@ -11,7 +11,7 @@ EVENTS_MAX_PAGE_SIZE = 300
 logger = logging.getLogger(__name__)
 
 
-def get_events(begin, end, event_types):
+def get_events(begin, end, event_types, **filter_kwargs):
     # prime the pump
     url = '{}{}/events'.format(settings.LISTSERV_API_URL,
                                settings.LISTSERV_DOMAIN)
@@ -22,6 +22,7 @@ def get_events(begin, end, event_types):
         'limit': EVENTS_MAX_PAGE_SIZE,
         'event': ' OR '.join(event_types),
     }
+    params.update(filter_kwargs)
     resp = requests.get(url, auth=auth, params=params)
     resp.raise_for_status()
     events = resp.json()['items']

--- a/mailgun/management/commands/mailgun_emails_failed.py
+++ b/mailgun/management/commands/mailgun_emails_failed.py
@@ -1,0 +1,95 @@
+import argparse
+import datetime
+import json
+import logging
+import requests
+import sys
+
+import pytz
+from django.core.management.base import BaseCommand
+from django.conf import settings
+
+from icommons_common.canvas_utils import UnicodeCSVWriter
+from mailgun.management.commands._mailgun_api import get_events
+
+
+EVENTS_OF_INTEREST = ('failed',)
+INPUT_DATETIME_FORMAT = '%Y%m%d%H%M%S'
+OUTPUT_DATETIME_FORMAT = '%Y-%m-%d %H:%M:%S  %Z%z'
+TZ = pytz.timezone('US/Eastern') # can't rely on settings, it's usually UTC
+UTC = pytz.timezone('UTC')
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = ('Prints a list of emails with permanent failures in a given time '
+            'window')
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--begin-time', type=_datetime, required=True,
+            help='Beginning of the window to look for emails, formatted as '
+                 'YYYYMMDDHHMMSS')
+        parser.add_argument(
+            '--end-time', type=_datetime, required=True,
+            help='End of the window to look for emails, formatted as '
+                 'YYYYMMDDHHMMSS')
+        parser.add_argument(
+            '--output-file', type=argparse.FileType('w'), default=sys.stdout,
+            help='File to output the csv of emails sent to, defaults to stdout')
+        parser.add_argument(
+            '--include-temporary', action='store_true', default=False,
+            help='Include temporary failures, defaults to False')
+
+    def handle(self, *args, **options):
+        filter_kwargs = {'severity': 'permanent'}
+        if options['include_temporary']:
+            filter_kwargs['severity'] += ' OR temporary'
+        events = get_events(options['begin_time'], options['end_time'],
+                            EVENTS_OF_INTEREST, **filter_kwargs)
+        self.process_events(events, options['output_file'])
+
+    def process_events(self, events, output_file):
+        rows = []
+        for event in events:
+            try:
+                sender = event['envelope']['sender']
+            except RuntimeError:
+                logger.exception('event {} missing a sender'.format(event))
+                continue
+
+            if sender.endswith(settings.LISTSERV_DOMAIN):
+                logger.error(
+                    u'Unexpectedly received a failure event for the mailer '
+                    u'sending to a user:\n%s', json.dumps(event))
+                continue
+
+            try:       
+                timestamp = datetime.datetime.fromtimestamp(event['timestamp'], UTC)
+                timestamp = timestamp.astimezone(TZ).strftime(OUTPUT_DATETIME_FORMAT)
+                list_addresses = [a for a in event['message']['recipients']
+                                      if a.endswith(settings.LISTSERV_DOMAIN)]
+                list_address = ';'.join(list_addresses)
+                row = (
+                    timestamp,
+                    list_address,
+                    sender,
+                    event['message']['headers']['subject'],
+                    event['message']['headers']['message-id'],
+                )
+            except KeyError as e:
+                logger.error('Unable to extract {} from event'.format(e.args[0]))
+            else:
+                rows.append(row)
+        rows.sort()
+
+        headers = ('timestamp', 'list', 'sender', 'subject', 'message-id')
+        writer = UnicodeCSVWriter(output_file)
+        writer.writerow(headers)
+        writer.writerows(rows)
+
+
+def _datetime(arg):
+    dt = datetime.datetime.strptime(arg, INPUT_DATETIME_FORMAT)
+    return TZ.localize(dt)


### PR DESCRIPTION
Usage:
```
$ python manage.py mailgun_emails_failed --help
usage: manage.py mailgun_emails_failed [-h] [--version] [-v {0,1,2,3}]
                                       [--settings SETTINGS]
                                       [--pythonpath PYTHONPATH] [--traceback]
                                       [--no-color] --begin-time BEGIN_TIME
                                       --end-time END_TIME
                                       [--output-file OUTPUT_FILE]
                                       [--include-temporary]

Prints a list of emails with permanent failures in a given time window

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  -v {0,1,2,3}, --verbosity {0,1,2,3}
                        Verbosity level; 0=minimal output, 1=normal output,
                        2=verbose output, 3=very verbose output
  --settings SETTINGS   The Python path to a settings module, e.g.
                        "myproject.settings.main". If this isn't provided, the
                        DJANGO_SETTINGS_MODULE environment variable will be
                        used.
  --pythonpath PYTHONPATH
                        A directory to add to the Python path, e.g.
                        "/home/djangoprojects/myproject".
  --traceback           Raise on CommandError exceptions
  --no-color            Don't colorize the command output.
  --begin-time BEGIN_TIME
                        Beginning of the window to look for emails, formatted
                        as YYYYMMDDHHMMSS
  --end-time END_TIME   End of the window to look for emails, formatted as
                        YYYYMMDDHHMMSS
  --output-file OUTPUT_FILE
                        File to output the csv of emails sent to, defaults to
                        stdout
  --include-temporary   Include temporary failures, defaults to False
```

Sample output:
```
$ python manage.py mailgun_emails_failed --begin 20150901000000 --end 20150930000000 --out foo.csv
$ head foo.csv
timestamp,list,sender,subject,message-id
2015-09-10 00:58:24  EDT-0400,canvas-6206-2423@mg.dev.tlt.harvard.edu,tlttest52@gmail.com,Re: New email:1 to section from student- tlttest53.,CAGKSEVDnPPcaED231h31yccK0wZYXSq5=wGvCJtOpHECS6nwEw@mail.gmail.com
2015-09-12 03:21:18  EDT-0400,canvas-5980@mg.dev.tlt.harvard.edu,danny_brooke@harvard.edu,test email,D218A2B0.44DA0%danny_brooke@harvard.edu
2015-09-19 00:46:32  EDT-0400,canvas-6389-1670@mg.dev.tlt.harvard.edu,josie_yip@harvard.edu,Staff access - please delete me,D221B8F6.A863%josie_yip@harvard.edu
2015-09-19 00:48:41  EDT-0400,canvas-6389-1670@mg.dev.tlt.harvard.edu,josie_yip@harvard.edu,test please delete me,D221B857.A860%josie_yip@harvard.edu
2015-09-19 01:28:47  EDT-0400,canvas-6389-1670@mg.dev.tlt.harvard.edu,josie_yip@harvard.edu,Staff only - please delete me,D221C198.A865%josie_yip@harvard.edu
2015-09-19 02:11:37  EDT-0400,canvas-6389-1670@mg.dev.tlt.harvard.edu,josie_yip@harvard.edu,Re: Staff only - please delete me,D221CC05.A866%josie_yip@harvard.edu
2015-09-19 04:59:55  EDT-0400,canvas-6389-1670@mg.dev.tlt.harvard.edu,tlttest53@gmail.com,test,CAOL0oGPF-_15YAqOr5rnKQSuBWB1+6bPYE1JHogvcdme1Y=MQg@mail.gmail.com
2015-09-22 08:29:40  EDT-0400,canvas-6389-1670@mg.dev.tlt.harvard.edu,pcyan2012@gmail.com,testing - please delete me,CAFRknW55J5BfHLRzq=GExSnpmT7Qsp1DpYskvMp-AEhGzAkZZg@mail.gmail.com
2015-09-22 08:37:26  EDT-0400,canvas-6389-1670@mg.dev.tlt.harvard.edu,tlttest53@gmail.com,Testing please delete me,CAOL0oGN0Zs65XMScyXBbzASv0OvYbwd8G+6beQ1sbXo2BqYDkw@mail.gmail.com
```