### PR TITLE
Sprint 32 TLT-1937 Fix unit tests for jenkins and sqlite

### DIFF
--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -10,6 +10,6 @@ django-angular==0.7.13
 flanker==0.4.34
 ndg-httpsclient==0.4.0
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.8.1#egg=canvas-python-sdk==0.8.1
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.7#egg=django-icommons-common==1.10.7
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.8#egg=django-icommons-common==1.10.8
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.4#egg=django-auth-lti==1.2.4

--- a/mailgun/tests.py
+++ b/mailgun/tests.py
@@ -19,6 +19,7 @@ from .decorators import authenticate
 from .route_handlers import handle_mailing_list_email_route
 
 
+@override_settings(LISTSERV_API_KEY=str(uuid.uuid4()))
 class RouteHandlerRegressionTests(TestCase):
     longMessage = True
 


### PR DESCRIPTION
* jenkins doesn't have an api key in settings, and unit tests
  shouldn't rely on it being there.  use the same settings override
  used elsewhere in that tests.py.
* generating test schema for sqlite failed due to it adding in an
  extra _id to a field name.  pull in the version of icommons-common
  that includes the fix.