### PR TITLE
Sprint 32 TLT-2039 Cache sent message ids

### DIFF
--- a/lti_emailer/settings/base.py
+++ b/lti_emailer/settings/base.py
@@ -304,3 +304,6 @@ MAILGUN_CALLBACK_TIMEOUT = 30 * 1000  # 30 seconds
 IGNORE_WHITELIST = SECURE_SETTINGS.get('ignore_whitelist', False)
 
 CACHE_KEY_LISTS_BY_CANVAS_COURSE_ID = "mailing_lists_by_canvas_course_id-%s"
+
+CACHE_KEY_MESSAGE_ID_SEEN = 'lti_emailer:message-id-seen:%s'
+CACHE_KEY_MESSAGE_ID_SEEN_TIMEOUT = 60 * 60 * 8 # 8 hours

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -28,7 +28,8 @@ class MailgunClient(object):
 
     def send_mail(self, list_address, from_address, to_address, subject='',
                   text='', html='', original_to_address=None,
-                  original_cc_address=None, attachments=None, inlines=None):
+                  original_cc_address=None, attachments=None, inlines=None,
+                  message_id=None):
         api_url = "%s%s/messages" % (settings.LISTSERV_API_URL,
                                      settings.LISTSERV_DOMAIN)
         payload = {
@@ -40,6 +41,10 @@ class MailgunClient(object):
             'text': text,
             'to': to_address,
         }
+
+        # include the message-id header if we got it
+        if message_id:
+            payload['Message-Id'] = message_id
 
         # we want the to/cc fields as received by list users to be as close
         # as possible to the same as those that were sent by the sender.

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -50,9 +50,19 @@ def handle_mailing_list_email_route(request):
 
     attachments, inlines = _get_attachments_inlines(request)
 
-    logger.info(u'Handling Mailgun mailing list email from %s to %s',
-                sender, recipient)
+    logger.info(u'Handling Mailgun mailing list email from %s to %s, '
+                u'subject %s, message id %s',
+                sender, recipient, subject, message_id)
     logger.debug(u'Full mailgun post: %s', request.POST)
+
+    # shortcut if we've already handled this message
+    if message_id:
+        cache_key = settings.CACHE_KEY_MESSAGE_ID_SEEN % message_id
+        if cache.get(cache_key):
+            logger.warning(u'Message-Id %s was posted to the route handler, '
+                           u'but we\'ve already handled that.  Dropping.',
+                           message_id)
+        return JsonResponse({'success': True})
 
     # if we want to check email addresses against the sender, we need to parse
     # out just the address.

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -44,6 +44,7 @@ def handle_mailing_list_email_route(request):
     subject = request.POST.get('subject')
     body_plain = request.POST.get('body-plain', '')
     body_html = request.POST.get('body-html', '')
+    message_id = request.POST.get('Message-Id')
     to_list = address.parse_list(request.POST.get('To'))
     cc_list = address.parse_list(request.POST.get('Cc'))
 
@@ -75,7 +76,8 @@ def handle_mailing_list_email_route(request):
             'message_body': body_plain or body_html,
         }))
         listserv_client.send_mail(recipient, recipient, sender_address,
-                                  subject='Undeliverable mail', html=content)
+                                  subject='Undeliverable mail', html=content,
+                                  message_id=message_id)
         return JsonResponse({'success': True})
 
     # Always include teaching staff addresses with members addresses, so that they can email any list in the course
@@ -106,7 +108,7 @@ def handle_mailing_list_email_route(request):
         }))
         subject = 'Undeliverable mail'
         ml.send_mail('', ml.address, sender_address, subject=subject,
-                     html=content)
+                     html=content, message_id=message_id)
     else:
         # try to prepend [SHORT TITLE] to subject, keep going if lookup fails
         try:
@@ -199,7 +201,7 @@ def handle_mailing_list_email_route(request):
                 sender_display_name, sender_address,
                 member_addresses, subject, text=body_plain, html=body_html,
                 original_to_address=to_list, original_cc_address=cc_list,
-                attachments=attachments, inlines=inlines
+                attachments=attachments, inlines=inlines, message_id=message_id
             )
         except RuntimeError:
             logger.exception(

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -2,6 +2,8 @@ import json
 import logging
 import re
 
+from django.conf import settings
+from django.core.cache import cache
 from django.http import JsonResponse
 from django.template import Context
 from django.template.loader import get_template

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -64,7 +64,7 @@ def handle_mailing_list_email_route(request):
             logger.warning(u'Message-Id %s was posted to the route handler, '
                            u'but we\'ve already handled that.  Dropping.',
                            message_id)
-        return JsonResponse({'success': True})
+            return JsonResponse({'success': True})
 
     # if we want to check email addresses against the sender, we need to parse
     # out just the address.

--- a/mailgun/tests.py
+++ b/mailgun/tests.py
@@ -11,12 +11,55 @@ from django.core.urlresolvers import reverse_lazy
 from django.test import TestCase, RequestFactory
 from django.test.utils import override_settings
 
-from mock import MagicMock, patch
+from mock import MagicMock, call, patch
 
 from icommons_common.utils import Bunch
 
 from .decorators import authenticate
 from .route_handlers import handle_mailing_list_email_route
+
+
+@override_settings(LISTSERV_API_KEY=str(uuid.uuid4()))
+class RouteHandlerUnitTests(TestCase):
+    longMessage = True
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.user = User.objects.create_user(username='unittest',
+                                             email='unittest@example.edu',
+                                             password='unittest')
+
+    @override_settings(CACHE_KEY_MESSAGE_ID_SEEN='%s')
+    @patch('mailgun.route_handlers.cache.get')
+    @patch('mailgun.route_handlers.CourseInstance.objects.get')
+    @patch('mailgun.route_handlers.MailingList.objects.get_or_create_or_delete_mailing_list_by_address')
+    def test_duplicate_router_post(self, mock_ml_get, mock_ci_get, mock_cache_get):
+        ''' TLT-2039
+        Verifies that if a message-id is in the cache, we won't try to send
+        that email to the list again.
+        '''
+        # only the message-id is needed
+        post_body = {
+            'Message-Id': uuid.uuid4().hex,
+        }
+        post_body.update(generate_signature_dict())
+
+        # the message-id is in the cache
+        mock_cache_get.return_value = True
+
+        # prep the request
+        request = self.factory.post('/', post_body)
+        request.user = self.user
+
+        # run the view, verify success
+        response = handle_mailing_list_email_route(request)
+        self.assertEqual(response.status_code, 200)
+
+        # verify cache.get we're expecting, and other mocks unused
+        self.assertEqual(mock_cache_get.call_args,
+                         call(post_body['Message-Id']))
+        self.assertEqual(mock_ml_get.call_count, 0)
+        self.assertEqual(mock_ci_get.call_count, 0)
 
 
 @override_settings(LISTSERV_API_KEY=str(uuid.uuid4()))

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -1,10 +1,11 @@
 import logging
 
 import re
-from flanker import addresslib
 from django.conf import settings
+from django.core.cache import cache
 from django.db import models
 from django.utils import timezone
+from flanker import addresslib
 
 from lti_emailer import canvas_api_client
 from mailgun.listserv_client import MailgunClient as ListservClient
@@ -228,17 +229,27 @@ class MailingList(models.Model):
 
     def send_mail(self, sender_display_name, sender_address, to_address,
                   subject='', text='', html='', original_to_address=None,
-                  original_cc_address=None, attachments=None, inlines=None):
-        logger.debug(u"in send_mail: sender_address=%s, to_address=%s, "
-                     u"mailing_list.address=%s ",
+                  original_cc_address=None, attachments=None, inlines=None,
+                  message_id=None):
+        logger.debug(u'in send_mail: sender_address=%s, to_address=%s, '
+                     u'mailing_list.address=%s ',
                      sender_address, to_address, self.address)
-        mailing_list_address = addresslib.address.parse(self.address)
-        mailing_list_address.display_name = sender_display_name
-        listserv_client.send_mail(
-            mailing_list_address.full_spec(), sender_address, to_address,
-            subject, text, html, original_to_address, original_cc_address,
-            attachments, inlines
-        )
+        cache_key = settings.CACHE_KEY_MESSAGE_ID_SEEN % message_id
+        if cache.get(cache_key):
+            logger.warning(u'Asked to send mail for message-id %s, but we\'ve '
+                           u'already sent one for it.  Dropping.',
+                           message_id)
+        else:
+            logger.debug(u'Sending mail for message-id %s', message_id)
+            mailing_list_address = addresslib.address.parse(self.address)
+            mailing_list_address.display_name = sender_display_name
+            listserv_client.send_mail(
+                mailing_list_address.full_spec(), sender_address, to_address,
+                subject, text, html, original_to_address, original_cc_address,
+                attachments, inlines, message_id
+            )
+            cache.set(cache_key, True,
+                      timeout=settings.CACHE_KEY_MESSAGE_ID_SEEN_TIMEOUT)
 
 
 class EmailWhitelist(models.Model):

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -234,22 +234,16 @@ class MailingList(models.Model):
         logger.debug(u'in send_mail: sender_address=%s, to_address=%s, '
                      u'mailing_list.address=%s ',
                      sender_address, to_address, self.address)
+        mailing_list_address = addresslib.address.parse(self.address)
+        mailing_list_address.display_name = sender_display_name
+        listserv_client.send_mail(
+            mailing_list_address.full_spec(), sender_address, to_address,
+            subject, text, html, original_to_address, original_cc_address,
+            attachments, inlines, message_id
+        )
         cache_key = settings.CACHE_KEY_MESSAGE_ID_SEEN % message_id
-        if cache.get(cache_key):
-            logger.warning(u'Asked to send mail for message-id %s, but we\'ve '
-                           u'already sent one for it.  Dropping.',
-                           message_id)
-        else:
-            logger.debug(u'Sending mail for message-id %s', message_id)
-            mailing_list_address = addresslib.address.parse(self.address)
-            mailing_list_address.display_name = sender_display_name
-            listserv_client.send_mail(
-                mailing_list_address.full_spec(), sender_address, to_address,
-                subject, text, html, original_to_address, original_cc_address,
-                attachments, inlines, message_id
-            )
-            cache.set(cache_key, True,
-                      timeout=settings.CACHE_KEY_MESSAGE_ID_SEEN_TIMEOUT)
+        cache.set(cache_key, True,
+                  timeout=settings.CACHE_KEY_MESSAGE_ID_SEEN_TIMEOUT)
 
 
 class EmailWhitelist(models.Model):


### PR DESCRIPTION
If we take too long to handle a router POST, Mailgun will time out (experiments suggest after 60 secs) and retry later.  If we actually sent the mail along (or sent a bounce email) the first time, then the Mailgun retry will trigger a duplicate email being sent.

This change caches the Message-Id of each email we handle (after sending a bounce, or after sending it to the list members).  It also checks that cache at the top of the router handler, and simply returns success if we know we've handled it before.  This way, when mailgun POSTs a retry, we respond that we've handled it, but we don't send the dupe.