### PR TITLE
Task/eparker71/tlt 2051   diff bounce back messages

### DIFF
--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -99,7 +99,7 @@ def handle_mailing_list_email_route(request):
         logger.info(
             u'Sending mailing list bounce back email to %s for mailing list %s '
             u'because the sender was not a member', sender, recipient)
-        bounce_back_email_template = get_template('mailgun/email/bounce_back_access_denied.html')
+        bounce_back_email_template = get_template('mailgun/email/bounce_back_not_subscribed.html')
     elif ml.access_level == MailingList.ACCESS_LEVEL_STAFF and sender_address not in teaching_staff_addresses:
         logger.info(
             u'Sending mailing list bounce back email to %s for mailing list %s '

--- a/mailgun/templates/mailgun/email/bounce_back_access_denied.html
+++ b/mailgun/templates/mailgun/email/bounce_back_access_denied.html
@@ -6,8 +6,8 @@
     <body>
         <h4>***Your message could not be delivered to mailing list {{ recipient }}.***</h4>
         <p>
-        Either you didn’t set your current email address as your default address in Canvas or you have
-            insufficient permission to email this list. Visit the <a href="https://wiki.harvard.edu/confluence/pages/viewpage.action?pageId=190909873">Course Emailer FAQ</a> for help.
+            The current settings of this mailing list do not allow students and guests to send
+            messages to the list. Teaching staff manage the settings of each mailing list. <a href="https://wiki.harvard.edu/confluence/pages/viewpage.action?pageId=190909873">Troubleshooting tips</a>
         </p>
         <p>------------------------------</p>
         <p><b>From:</b> {{ sender }}</p>

--- a/mailgun/templates/mailgun/email/bounce_back_not_subscribed.html
+++ b/mailgun/templates/mailgun/email/bounce_back_not_subscribed.html
@@ -1,0 +1,19 @@
+<html>
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+        <meta name="viewport" content="width=device-width">
+    </head>
+    <body>
+        <h4>***Your message could not be delivered to mailing list {{ recipient }}.***</h4>
+        <p>
+            You are not currently subscribed to this list. If this is an error, please contact the course teaching staff
+            or visit the <a href="https://wiki.harvard.edu/confluence/pages/viewpage.action?pageId=190909873">Course Emailer FAQ</a> for help.
+        </p>
+
+        <p>------------------------------</p>
+        <p><b>From:</b> {{ sender }}</p>
+        <p><b>To:</b> {{ recipient }}</p>
+        <p><b>Subject:</b> {{ subject }}</p>
+        <p>{{ message_body }}</p>
+    </body>
+</html>

--- a/mailgun/templates/mailgun/email/bounce_back_not_subscribed.html
+++ b/mailgun/templates/mailgun/email/bounce_back_not_subscribed.html
@@ -6,8 +6,9 @@
     <body>
         <h4>***Your message could not be delivered to mailing list {{ recipient }}.***</h4>
         <p>
-            You are not currently subscribed to this list. If this is an error, please contact the course teaching staff
-            or visit the <a href="https://wiki.harvard.edu/confluence/pages/viewpage.action?pageId=190909873">Course Emailer FAQ</a> for help.
+            This mailing list does not recognize the email address you are using. This could be because 1) you are not
+            enrolled in the course or section, or 2) because you are attempting to send from an email address that is
+            not your default address in your Canvas account. <a href="https://wiki.harvard.edu/confluence/pages/viewpage.action?pageId=190909873">Troubleshooting tips</a>
         </p>
 
         <p>------------------------------</p>

--- a/mailing_list/templates/mailing_list/admin_index.html
+++ b/mailing_list/templates/mailing_list/admin_index.html
@@ -46,8 +46,7 @@ $(document).ready(function(){
           <h2>Mailing Lists for {{course_name}}</h2>
             <p class="caption">
               This tool provides mailing lists that allow you to contact members of your course using an email
-              client (e.g. Outlook, Gmail, etc.) as an alternative to the Canvas Inbox. If you would like a copy of
-              your email, add your own email address to the CC or BCC field. You <b>must</b> send your message from the email
+              client (e.g. Outlook, Gmail, etc.) as an alternative to the Canvas Inbox. You <b>must</b> send your message from the email
               address that is set as your default in Canvas or your message will not be delivered.
                 <a target="_blank"
                    href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer "

--- a/mailing_list/templates/mailing_list/admin_index.html
+++ b/mailing_list/templates/mailing_list/admin_index.html
@@ -46,7 +46,8 @@ $(document).ready(function(){
           <h2>Mailing Lists for {{course_name}}</h2>
             <p class="caption">
               This tool provides mailing lists that allow you to contact members of your course using an email
-              client (e.g. Outlook, Gmail, etc.) as an alternative to the Canvas Inbox. You <b>must</b> send your message from the email
+              client (e.g. Outlook, Gmail, etc.) as an alternative to the Canvas Inbox. If you would like a copy of
+              your email, add your own email address to the CC or BCC field. You <b>must</b> send your message from the email
               address that is set as your default in Canvas or your message will not be delivered.
 
                 <a target="_blank"


### PR DESCRIPTION
In this PR:

1 ) removed CC/BCC text from admin_index.html for story TLT-1927

Original text (missing from the PR):
``` 
This tool provides mailing lists that allow you to contact members of your course using an email 
client (e.g. Outlook, Gmail, etc.) as an alternative to the Canvas Inbox. If you would like a copy 
of your email, add your own email address to the CC or BCC field. You <b>must</b> send your 
message from the email client (e.g. Outlook, Gmail, etc.) as an alternative to the Canvas Inbox. 
You <b>must</b> send your message from the email address that is set as your default in Canvas 
or your message will not be delivered.
```

New text:
``` 
This tool provides mailing lists that allow you to contact members of your course using an email 
client (e.g. Outlook, Gmail, etc.) as an alternative to the Canvas Inbox. You <b>must</b> send 
your message from the email client (e.g. Outlook, Gmail, etc.) as an alternative to the Canvas 
Inbox. You <b>must</b> send your message from the email address that is set as your default 
in Canvas or your message will not be delivered.
```

2) added new bounce back template bounce_back_not_subscribed.html to trigger when the 
user is not a member of the list. The text in this template will probably change, but the functionality should not.
