### PR TITLE
Sprint 23 TLT-2069 Fix regression in permission check

### DIFF
--- a/lti_emailer/canvas_api_client.py
+++ b/lti_emailer/canvas_api_client.py
@@ -104,7 +104,7 @@ def get_teaching_staff_enrollments(canvas_course_id):
             role = enrollment['role']
             if role not in roles_allowed:
                 roles_allowed[enrollment['role']] = is_allowed(
-                    role,
+                    [role],
                     settings.PERMISSION_LTI_EMAILER_SEND_ALL,
                     canvas_course_id
                 )


### PR DESCRIPTION
We were passing in a string where lti_permissions expected a list of strings.  Follow-on change to lti_permissions to catch that case there coming soon.