### PR TITLE
short title (of primary course) now appears in the subject line of em…

### DIFF
--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -10,6 +10,6 @@ django-angular==0.7.13
 flanker==0.4.34
 ndg-httpsclient==0.4.0
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.8.1#egg=canvas-python-sdk==0.8.1
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.8#egg=django-icommons-common==1.10.8
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.8#egg=django-icommons-common==1.10.15
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.4#egg=django-auth-lti==1.2.4

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -10,6 +10,6 @@ django-angular==0.7.13
 flanker==0.4.34
 ndg-httpsclient==0.4.0
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.8.1#egg=canvas-python-sdk==0.8.1
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.8#egg=django-icommons-common==1.10.15
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.15#egg=django-icommons-common==1.10.15
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.4#egg=django-auth-lti==1.2.4

--- a/mailgun/tests.py
+++ b/mailgun/tests.py
@@ -31,7 +31,7 @@ class RouteHandlerUnitTests(TestCase):
 
     @override_settings(CACHE_KEY_MESSAGE_ID_SEEN='%s')
     @patch('mailgun.route_handlers.cache.get')
-    @patch('mailgun.route_handlers.CourseInstance.objects.get')
+    @patch('mailgun.route_handlers.get_course_instance_by_canvas_course_id')
     @patch('mailgun.route_handlers.MailingList.objects.get_or_create_or_delete_mailing_list_by_address')
     def test_duplicate_router_post(self, mock_ml_get, mock_ci_get, mock_cache_get):
         ''' TLT-2039
@@ -72,7 +72,7 @@ class RouteHandlerRegressionTests(TestCase):
                                              email='unittest@example.edu',
                                              password='unittest')
 
-    @patch('mailgun.route_handlers.CourseInstance.objects.get')
+    @patch('mailgun.route_handlers.get_course_instance_by_canvas_course_id')
     @patch('mailgun.route_handlers.MailingList.objects.get_or_create_or_delete_mailing_list_by_address')
     def test_empty_body_html(self, mock_ml_get, mock_ci_get):
         ''' TLT-2006


### PR DESCRIPTION
…ails to mailing lists in cross-listed courses. This depends on https://github.com/Harvard-University-iCommons/django-icommons-common/pull/128 (`lti_permissions.verification` had the exact logic needed to fix this).