### PR TITLE
Sprint 34 TLT-2114 Detect and break bounce loops

### DIFF
--- a/mailgun/test_scripts/tlt-2114-dev-environment-integration-test.py
+++ b/mailgun/test_scripts/tlt-2114-dev-environment-integration-test.py
@@ -27,7 +27,7 @@ def generate_signature_dict():
 list_address = 'canvas-6760-2069@mg.dev.tlt.harvard.edu'
 post_body = {
     'sender': 'Integration Test <integrationtest@example.edu>',
-    'from': list_address,
+    'from': settings.NO_REPLY_ADDRESS,
     'recipient': list_address,
     'subject': 'blah',
     'body-plain': 'blah blah',

--- a/mailgun/test_scripts/tlt-2114-dev-environment-integration-test.py
+++ b/mailgun/test_scripts/tlt-2114-dev-environment-integration-test.py
@@ -43,7 +43,12 @@ post_body = {
 }
 post_body.update(generate_signature_dict())
 
+# figure out which server to post to
+env_name = settings.ENV_NAME
+if env_name not in ('dev', 'qa', 'stage'):
+    env_name = 'dev'
+
 # post it
-url = 'https://lti-emailer.dev.tlt.harvard.edu/mailgun/handle_mailing_list_email_route/'
+url = 'https://lti-emailer.%s.tlt.harvard.edu/mailgun/handle_mailing_list_email_route/' % env _name
 resp = requests.post(url, data=post_body)
 resp.raise_for_status()

--- a/mailgun/test_scripts/tlt-2114-dev-environment-integration-test.py
+++ b/mailgun/test_scripts/tlt-2114-dev-environment-integration-test.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python
+
+import hashlib
+import hmac
+import json
+import time
+import uuid
+
+import requests
+from django.conf import settings
+
+def generate_signature_dict():
+    timestamp = str(time.time())
+    token = str(uuid.uuid4())
+    signature = hmac.new(
+        key=settings.LISTSERV_API_KEY,
+        msg='{}{}'.format(timestamp, token),
+        digestmod=hashlib.sha256
+    ).hexdigest()
+    return {
+        'timestamp': timestamp,
+        'token': token,
+        'signature': signature
+    }
+
+# prep the post body
+list_address = 'canvas-6760-2069@mg.dev.tlt.harvard.edu'
+post_body = {
+    'sender': 'Integration Test <integrationtest@example.edu>',
+    'from': list_address,
+    'recipient': list_address,
+    'subject': 'blah',
+    'body-plain': 'blah blah',
+    'To': list_address,
+}
+post_body.update(generate_signature_dict())
+
+# post it
+url = 'https://lti-emailer.dev.tlt.harvard.edu/mailgun/handle_mailing_list_email_route/'
+resp = requests.post(url, data=post_body)
+resp.raise_for_status()

--- a/mailgun/test_scripts/tlt-2114-dev-environment-integration-test.py
+++ b/mailgun/test_scripts/tlt-2114-dev-environment-integration-test.py
@@ -9,6 +9,14 @@ import uuid
 import requests
 from django.conf import settings
 
+try:
+    settings.NO_REPLY_ADDRESS
+except ImportError:
+    # make sure the project root is in sys.path
+    import os, sys
+    sys.path.insert(0, os.path.normpath(
+                           os.path.join(os.path.abspath(__file__), '..', '..', '..')))
+
 def generate_signature_dict():
     timestamp = str(time.time())
     token = str(uuid.uuid4())

--- a/mailgun/tests.py
+++ b/mailgun/tests.py
@@ -210,7 +210,7 @@ class RouteHandlerRegressionTests(TestCase):
         # prep the post body
         post_body = {
             'sender': 'Unit Test <unittest@example.edu>',
-            'from': list_address,
+            'from': settings.NO_REPLY_ADDRESS,
             'recipient': list_address,
             'subject': 'blah',
             'body-plain': 'blah blah',


### PR DESCRIPTION
Adds a check that compares the recipient and from addresses.  If they match, we've got a bounce loop, and we want to drop the email.

Includes a short script used to integration test this.  I made several attempts to provoke the drop via actual email sent through office365 and g.harvard.edu, none of which succeeded.  In the end, I had to resort to doing the POST to the router myself.