### PR TITLE
Adds general exception handling to email route handler

### DIFF
--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 listserv_client = ListservClient()
 
 
-def log_and_report_errors():
+def handle_uncaught_exceptions():
     def decorator(view_func):
         @wraps(view_func, assigned=available_attrs(view_func))
         def inner(request, *args, **kwargs):
@@ -46,7 +46,7 @@ def log_and_report_errors():
 @csrf_exempt
 @authenticate()
 @require_http_methods(['POST'])
-@log_and_report_errors()
+@handle_uncaught_exceptions()
 def handle_mailing_list_email_route(request):
     '''
     Handles the Mailgun route action when email is sent to a Mailgun mailing list.

--- a/mailgun/tests.py
+++ b/mailgun/tests.py
@@ -70,7 +70,6 @@ class RouteHandlerUnitTests(TestCase):
     def test_unhandled_exception(self, mock_handle_recipient, mock_log_exc):
         '''
         TLT-2130: Should log mailgun POST on unhandled exception
-        and request mailgun stop processing message
         '''
 
         # mock an unhandled error in the method that sends mail to a recipient
@@ -88,8 +87,9 @@ class RouteHandlerUnitTests(TestCase):
 
         response = handle_mailing_list_email_route(request)
 
-        # expecting 406 failure (per mailgun's requirements)
-        self.assertEqual(response.status_code, 406)
+        # expecting server error
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.content, json.dumps({'success': False}))
 
         # verify we logged post data
         self.assertEqual(mock_log_exc.call_count, 1)

--- a/mailgun/tests.py
+++ b/mailgun/tests.py
@@ -95,7 +95,6 @@ class RouteHandlerUnitTests(TestCase):
         self.assertEqual(mock_log_exc.call_count, 1)
         logger_post_info = mock_log_exc.call_args[0][1]  # second positional arg
         self.assertEqual(json.dumps(post_body), logger_post_info, 1)
-        # self.assertDictContainsSubset(post_body, logger_post_info, 1)
 
 
 @override_settings(LISTSERV_API_KEY=str(uuid.uuid4()))


### PR DESCRIPTION
* all failures, including MailingList.send_mail() errors and unhandled errors, now return HTTP 500 response to mailgun with {success:false}, to notify of an error and ask to retry later
* failures also log full POST data from mailgun at level ERROR