### PR TITLE
Task/sapnamysore/tlt 2131/logging for webhooks

### DIFF
--- a/mailgun/urls.py
+++ b/mailgun/urls.py
@@ -6,4 +6,5 @@ from mailgun import views, route_handlers
 urlpatterns = [
     url(r'^handle_mailing_list_email_route/', route_handlers.handle_mailing_list_email_route, name='handle_mailing_list_email_route'),
     url(r'^auth_error/', views.auth_error, name='auth_error'),
+    url(r'^log_post_data/', views.log_post_data, name='log_post_data'),
 ]

--- a/mailgun/views.py
+++ b/mailgun/views.py
@@ -2,7 +2,9 @@ import logging
 
 from django.http import JsonResponse
 from django.views.decorators.http import require_http_methods
-
+from django.http import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+from mailgun.decorators import authenticate
 
 logger = logging.getLogger(__name__)
 
@@ -10,3 +12,19 @@ logger = logging.getLogger(__name__)
 @require_http_methods(['GET'])
 def auth_error(request):
     return JsonResponse({'error': 'Failed to authenticate request.'}, status=401)
+
+
+@csrf_exempt
+@authenticate()
+@require_http_methods(['POST'])
+def log_post_data(request):
+    """
+    This method will help in logging the POST information. This method is provided as an endpoint for the
+    Mailgun Webhooks to log an event, so that we can track the various configured  events that are available
+    (such as Delivered, Dropped, Bounces, etc)
+    :param request:
+    :return HttpResponse:
+    """
+    logger.info(" in log_post_data")
+    logger.info(" Full mailgun post: %s", request.POST)
+    return HttpResponse("Succesfully logged", status=200)

--- a/mailgun/views.py
+++ b/mailgun/views.py
@@ -26,5 +26,5 @@ def log_post_data(request):
     :param request:
     :return HttpResponse:
     """
-    logger.info(u'[MAILGUN EVENT] %s', json.dumps(request.POST))
+    logger.info(u'[MAILGUN EVENT] %s', json.dumps(request.POST, indent=4, sort_keys=True))
     return HttpResponse("Successfully logged post data", status=200)

--- a/mailgun/views.py
+++ b/mailgun/views.py
@@ -20,11 +20,11 @@ def auth_error(request):
 @require_http_methods(['POST'])
 def log_post_data(request):
     """
-    This method will help in logging the POST information. This method is provided as an endpoint for the
+    This method will help in logging POST data. This method is provided as an endpoint for the
     Mailgun Webhooks to log an event, so that we can monitor the various configured  events that are available
     (such as Delivered, Dropped, Bounces, etc)
     :param request:
     :return HttpResponse:
     """
-    logger.info(u'[MAILGUN EVENT] %s ', json.dumps(request.POST))
+    logger.info('(MAILGUN EVENT) %s', json.dumps(request.POST))
     return HttpResponse("Successfully logged post data", status=200)

--- a/mailgun/views.py
+++ b/mailgun/views.py
@@ -1,4 +1,5 @@
 import logging
+import json
 
 from django.http import JsonResponse
 from django.views.decorators.http import require_http_methods
@@ -15,26 +16,15 @@ def auth_error(request):
 
 
 @csrf_exempt
-# @authenticate()
+@authenticate()
 @require_http_methods(['POST'])
 def log_post_data(request):
     """
     This method will help in logging the POST information. This method is provided as an endpoint for the
-    Mailgun Webhooks to log an event, so that we can track the various configured  events that are available
+    Mailgun Webhooks to log an event, so that we can monitor the various configured  events that are available
     (such as Delivered, Dropped, Bounces, etc)
     :param request:
     :return HttpResponse:
     """
-    logger.info(" Logging Webhook Post data")
-
-    # Log the event type , time and description
-    for key, value in request.POST.iteritems():
-        logger.info(" Key= %s, Value =%s", key, value)
-
-    logger.info("[MAILGUN EVENT] Type:%s, Recipient:%s, Error:%s, Reason:%s, Message-header:%s",
-                request.POST.get('event'),
-                request.POST.get('recipient'),
-                request.POST.get('error'),
-                request.POST.get('reason'),
-                request.POST.get('message-headers'))
+    logger.info("[MAILGUN EVENT] %s", json.dumps(request.POST))
     return HttpResponse("Successfully logged post data", status=200)

--- a/mailgun/views.py
+++ b/mailgun/views.py
@@ -26,5 +26,5 @@ def log_post_data(request):
     :param request:
     :return HttpResponse:
     """
-    logger.info('(MAILGUN EVENT) %s', json.dumps(request.POST))
+    logger.info(u'[MAILGUN EVENT] %s', json.dumps(dict(request.POST)))
     return HttpResponse("Successfully logged post data", status=200)

--- a/mailgun/views.py
+++ b/mailgun/views.py
@@ -25,13 +25,16 @@ def log_post_data(request):
     :param request:
     :return HttpResponse:
     """
-    # logger.info(" Full mailgun post: %s", request.POST)
     logger.info(" Logging Webhook Post data")
 
     # Log the event type , time and description
     for key, value in request.POST.iteritems():
         logger.info(" Key= %s, Value =%s", key, value)
 
-    logger.info(" Webhook event type:%s, Recipient:%s, Message-header:%s", request.POST.get('event'),
-                request.POST.get('recipient'), request.POST.get('message-headers'))
+    logger.info("[MAILGUN EVENT] Type:%s, Recipient:%s, Error:%s, Reason:%s, Message-header:%s",
+                request.POST.get('event'),
+                request.POST.get('recipient'),
+                request.POST.get('error'),
+                request.POST.get('reason'),
+                request.POST.get('message-headers'))
     return HttpResponse("Successfully logged post data", status=200)

--- a/mailgun/views.py
+++ b/mailgun/views.py
@@ -26,5 +26,5 @@ def log_post_data(request):
     :param request:
     :return HttpResponse:
     """
-    logger.info("[MAILGUN EVENT] %s", json.dumps(request.POST))
+    logger.info(u'[MAILGUN EVENT] %s ', json.dumps(request.POST))
     return HttpResponse("Successfully logged post data", status=200)

--- a/mailgun/views.py
+++ b/mailgun/views.py
@@ -25,6 +25,13 @@ def log_post_data(request):
     :param request:
     :return HttpResponse:
     """
-    logger.info(" in log_post_data")
-    logger.info(" Full mailgun post: %s", request.POST)
-    return HttpResponse("Succesfully logged", status=200)
+    # logger.info(" Full mailgun post: %s", request.POST)
+    logger.info(" Logging Webhook Post data")
+
+    # Log the event type , time and description
+    for key, value in request.POST.iteritems():
+        logger.info(" Key= %s, Value =%s", key, value)
+
+    logger.info(" Webhook event type:%s, Recipient:%s, Message-header:%s", request.POST.get('event'),
+                request.POST.get('recipient'), request.POST.get('message-headers'))
+    return HttpResponse("Successfully logged post data", status=200)

--- a/mailgun/views.py
+++ b/mailgun/views.py
@@ -20,9 +20,9 @@ def auth_error(request):
 @require_http_methods(['POST'])
 def log_post_data(request):
     """
-    This method will help in logging POST data. This method is provided as an endpoint for the
-    Mailgun Webhooks to log an event, so that we can monitor the various configured  events that are available
-    (such as Delivered, Dropped, Bounces, etc)
+    This method will log POST data. It is primarily provided so that it can be configured as an endpoint for the
+    Mailgun Webhooks to log an event, which would help in monitoring  the various configured  events that are available
+    (such as Delivered, Dropped, Bounces, etc). But it could also be used to log any post.
     :param request:
     :return HttpResponse:
     """

--- a/mailgun/views.py
+++ b/mailgun/views.py
@@ -26,5 +26,5 @@ def log_post_data(request):
     :param request:
     :return HttpResponse:
     """
-    logger.info(u'[MAILGUN EVENT] %s', json.dumps(dict(request.POST)))
+    logger.info(u'[MAILGUN EVENT] %s', json.dumps(request.POST))
     return HttpResponse("Successfully logged post data", status=200)

--- a/mailgun/views.py
+++ b/mailgun/views.py
@@ -15,7 +15,7 @@ def auth_error(request):
 
 
 @csrf_exempt
-@authenticate()
+# @authenticate()
 @require_http_methods(['POST'])
 def log_post_data(request):
     """


### PR DESCRIPTION
This PR contains changes creating an endpoint that would log  mailgun webhooks post  so that they can easily found in Splunk. More details in JIRA
https://jira.huit.harvard.edu/browse/TLT-2131

Initially I was logging certain keys, but also checked with Devops and they suggested logging the complete data as JSON with some identifiable  prefix. 

Webhooks are currently setup in Dev  for some events and I can see the logs in Splunk with the following query :
tag=dev sourcetype=django_app source="/var/opt/tlt/logs/django-lti_emailer.log" "MAILGUN EVENT"