### PR TITLE
Removed pretty print

### DIFF
--- a/mailgun/views.py
+++ b/mailgun/views.py
@@ -26,5 +26,5 @@ def log_post_data(request):
     :param request:
     :return HttpResponse:
     """
-    logger.info(u'[MAILGUN EVENT] %s', json.dumps(request.POST, indent=4, sort_keys=True))
+    logger.info(u'[MAILGUN EVENT] %s', json.dumps(request.POST, separators=(',', ': '), sort_keys=True))
     return HttpResponse("Successfully logged post data", status=200)


### PR DESCRIPTION
This PR contains a change to remove pretty printing of the webhook logging as a newline in some of the events didn't work well in the Splunk view.

From Python docs: 
*If indent is a non-negative integer, then JSON array elements and object members will be pretty-printed with that indent level. An indent level of 0, or negative, will only insert newlines. None (the default) selects the most compact representation.

Note Since the default item separator is ', ', the output might include trailing whitespace when indent is specified. You can use separators=(',', ': ') to avoid this.*