### PR TITLE
Sprint 37 TLT-2108 Handle missing attachments cleanly

### DIFF
--- a/mailgun/exceptions.py
+++ b/mailgun/exceptions.py
@@ -1,3 +1,20 @@
+from django.http import HttpResponse
+
+
 class HttpResponseException(RuntimeError):
+    '''Encapsulates a django.http.HttpResponse.  Intended to be caught at the
+    top level of a view (or by a view decorator) to allow code within a view
+    to immediately return a response.'''
+
     def __init__(self, response):
+        if not isinstance(response, HttpResponse):
+            raise TypeError(
+                      u'HttpResponseException expected an HttpResponse, got'
+                      u'a {}'.format(type(response)))
         self.response = response
+
+
+    def __unicode__(self):
+        return u'HttpResponseException<{} {}>: {}'.format(
+                   type(self.response), self.response.status_code,
+                   unicode(self.response))

--- a/mailgun/exceptions.py
+++ b/mailgun/exceptions.py
@@ -1,0 +1,3 @@
+class HttpResponseException(RuntimeError):
+    def __init__(self, response):
+        self.response = response


### PR DESCRIPTION
Notice missing attachments in the POST, log the fact that it was missing, and return a 400 error to mailgun.

NOTE: This adds the capability to raise an encapsulated HttpResponse from within the route handler, and to have it returned.  Also includes a unit test for that functionality.