### PR TITLE
Accept SIS IDs for accounts and terms; allow multiple terms

### DIFF
--- a/mailing_list/management/commands/activate_all_lists.py
+++ b/mailing_list/management/commands/activate_all_lists.py
@@ -20,9 +20,11 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('--account-id', required=True,
-                            help='Canvas account id (e.g. 29) or SIS account ID (e.g. sis_account_id:school:hls)')
-        parser.add_argument('--enrollment-term-id', nargs='*', required=True,
-                            help='Canvas enrollment term id (e.g. 1234) or SIS term ID (e.g. sis_term_id:2015-2)')
+                            help='Canvas account id (e.g. 29) or SIS account ID \
+                                  (e.g. sis_account_id:school:hls)')
+        parser.add_argument('--enrollment-term-id', nargs='+', required=True,
+                            help='Canvas enrollment term id (e.g. 1234) or SIS term ID \
+                                  (e.g. sis_term_id:2015-2)')
         parser.add_argument('--output-file', type=argparse.FileType('w'),
                             help='File to output mailing list details to')
 
@@ -38,7 +40,7 @@ class Command(BaseCommand):
                 pass
             except RuntimeError as e:
                 raise CommandError(str(e))
-        
+
         course_lists, failures = {}, {}
         num_lists = 0
         defaults = {'access_level': MailingList.ACCESS_LEVEL_MEMBERS}

--- a/mailing_list/management/commands/activate_all_lists.py
+++ b/mailing_list/management/commands/activate_all_lists.py
@@ -8,7 +8,7 @@ from icommons_common.canvas_utils import UnicodeCSVWriter
 
 from lti_emailer.canvas_api_client import get_courses_for_account_in_term
 from mailing_list.models import MailingList
-
+from canvas_sdk.exceptions import CanvasAPIError
 
 OUTPUT_FIELDS = ['id', 'sis_course_id', 'name', 'course_code']
 
@@ -19,21 +19,26 @@ class Command(BaseCommand):
     help = 'Activates all mailing lists for a given account and enrollment term'
 
     def add_arguments(self, parser):
-        parser.add_argument('--account-id', type=int, required=True,
-                            help='Canvas account id')
-        parser.add_argument('--enrollment-term-id', type=int, required=True,
-                            help='Canvas enrollment term id')
+        parser.add_argument('--account-id', required=True,
+                            help='Canvas account id (e.g. 29) or SIS account ID (e.g. sis_account_id:school:hls)')
+        parser.add_argument('--enrollment-term-id', nargs='*', required=True,
+                            help='Canvas enrollment term id (e.g. 1234) or SIS term ID (e.g. sis_term_id:2015-2)')
         parser.add_argument('--output-file', type=argparse.FileType('w'),
                             help='File to output mailing list details to')
 
     def handle(self, *args, **options):
-        try:
-            courses = get_courses_for_account_in_term(
-                options['account_id'], options['enrollment_term_id']
-            )
-        except RuntimeError as e:
-            raise CommandError(str(e))
-
+        courses = []
+        for term_id in options['enrollment_term_id']:
+            try:
+                courses += get_courses_for_account_in_term(
+                    options['account_id'], term_id
+                ) or []
+            except CanvasAPIError as e:
+                # don't raise the error
+                pass
+            except RuntimeError as e:
+                raise CommandError(str(e))
+        
         course_lists, failures = {}, {}
         num_lists = 0
         defaults = {'access_level': MailingList.ACCESS_LEVEL_MEMBERS}


### PR DESCRIPTION
* allow the account-id parameter to be passed as either the numeric Canvas ID or the sis_account_id
* allow the enrollment-term-id parameter to be passed as either the numeric Canvas ID or the sis_term_id
* allow multiple enrollment-term-id values to be passed in