### PR TITLE
Sprint 44 TLT-1310 Exit regression suite with error on test failure, some fixes

### DIFF
--- a/lti_emailer/requirements/local.txt
+++ b/lti_emailer/requirements/local.txt
@@ -13,9 +13,9 @@ flake8==2.4.1
 # selenium
 PyVirtualDisplay==0.1.5
 ddt==1.0.1
-selenium==2.48.0
+selenium==2.53.1
 xlrd==0.9.4
-git+ssh://git@github.com/Harvard-University-iCommons/selenium_common.git@v1.0#egg=selenium-common==1.0
+git+ssh://git@github.com/Harvard-University-iCommons/selenium_common.git@v1.4.3#egg=selenium-common==1.4.3
 
 
 # icommons_common unit tests depend on ccsw, and ccsw depends on icommons_common.

--- a/lti_emailer/settings/base.py
+++ b/lti_emailer/settings/base.py
@@ -309,3 +309,13 @@ CACHE_KEY_MESSAGE_HANDLED_BY_MESSAGE_ID_AND_RECIPIENT = "lti_emailer:message-han
 CACHE_KEY_MESSAGE_HANDLED_TIMEOUT = 60 * 60 * 8  # 8 hours
 
 NO_REPLY_ADDRESS = SECURE_SETTINGS.get('no_reply_address', 'no-reply@coursemail.harvard.edu')
+
+
+ICOMMONS_REST_API_TOKEN = SECURE_SETTINGS.get('icommons_rest_api_token')
+ICOMMONS_REST_API_HOST = SECURE_SETTINGS.get('icommons_rest_api_host')
+
+# Allows the REST API passthrough to successfully negotiate an SSL session
+# with an unverified certificate, e.g. the one that ships with django-sslserver
+# Default to False, but if testing locally, set to True
+ICOMMONS_REST_API_SKIP_CERT_VERIFICATION = SECURE_SETTINGS.get(
+            'icommons_rest_api_skip_cert_verification', False)

--- a/lti_emailer/settings/local.py
+++ b/lti_emailer/settings/local.py
@@ -17,13 +17,16 @@ DEBUG_TOOLBAR_CONFIG = {
 dictConfig(LOGGING)
 
 SELENIUM_CONFIG = {
-    'selenium_username': SECURE_SETTINGS.get('selenium_user'),
-    'selenium_password': SECURE_SETTINGS.get('selenium_password'),
-    'selenium_grid_url': SECURE_SETTINGS.get('selenium_grid_url'),
     'canvas_base_url': SECURE_SETTINGS.get('canvas_url'),
-    'run_locally': True,
-    'emailer_tool_relative_url': 'courses/6389/external_tools/',
-    'emailer_tool_id': '1759',
     'emailer_course_id':'6389',
+    'emailer_tool_id': '1759',
+    'emailer_tool_relative_url': 'courses/6389/external_tools/',
+    'icommons_rest_api': {
+        'base_path': 'api/course/v2'
+    },
+    'run_locally': SECURE_SETTINGS.get('selenium_run_locally', False),
+    'selenium_grid_url': SECURE_SETTINGS.get('selenium_grid_url'),
+    'selenium_password': SECURE_SETTINGS.get('selenium_password'),
+    'selenium_username': SECURE_SETTINGS.get('selenium_user'),
     'use_htmlrunner': SECURE_SETTINGS.get('selenium_use_htmlrunner', True),
 }

--- a/selenium_tests/lti_emailer/emailer_permission_tests.py
+++ b/selenium_tests/lti_emailer/emailer_permission_tests.py
@@ -4,7 +4,7 @@ from ddt import ddt, data, unpack
 
 from selenium_common.base_test_case import get_xl_data
 from selenium_tests.lti_emailer.emailer_base_test_case import CANVAS_ADD_USERS
-from selenium_common.masquerade.canvas_masquerade_page_object import CanvasMasqueradePageObject
+from selenium_common.canvas.canvas_masquerade_page_object import CanvasMasqueradePageObject
 from selenium_tests.lti_emailer.emailer_base_test_case import \
     EmailerBaseTestCase
 


### PR DESCRIPTION
This change also bumps the versions of selenium and selenium_common,
with corresponding fixes to settings and some selenium tests to attempt
to get the tests to pass.  At this point they're still failing, but due
to a nonsense-looking tool_id being used.  Since this change was just
supposed to get failures to return an error code, and they're now doing
that, i'm calling it a day here.