### PR TITLE
Sprint 45 TLT-2306 Send dummy body to mailgun if there is no body

### DIFF
--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -43,6 +43,11 @@ class MailgunClient(object):
             'to': to_address,
         }
 
+        # mailgun rejects emails with empty text and html bodies.  if both
+        # are empty, use a single space as the text body to work around that.
+        if not html and not text:
+            payload['text'] = ' '
+
         # include the message-id header if we got it
         if message_id:
             payload['Message-Id'] = message_id

--- a/mailgun/test_scripts/tlt-2306-empty-bodies-integration-test.py
+++ b/mailgun/test_scripts/tlt-2306-empty-bodies-integration-test.py
@@ -41,7 +41,6 @@ base_post = {
     'sender': 'Integration Test <integrationtest@example.edu>',
     'from': settings.NO_REPLY_ADDRESS,
     'recipient': list_address,
-    'subject': 'blah',
     'To': list_address,
 }
 base_post.update(generate_signature_dict())
@@ -57,6 +56,7 @@ posts = []
 for body in bodies:
     post = copy.deepcopy(base_post)
     post.update(body)
+    post['subject'] = 'empty body test where body="{}"'.format(json.dumps(body))
     posts.append(post)
 
 # figure out which server to post to

--- a/mailgun/test_scripts/tlt-2306-empty-bodies-integration-test.py
+++ b/mailgun/test_scripts/tlt-2306-empty-bodies-integration-test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+import copy
+import hashlib
+import hmac
+import json
+import time
+import uuid
+
+import requests
+from django.conf import settings
+
+try:
+    settings.NO_REPLY_ADDRESS
+except ImportError:
+    # make sure the project root is in sys.path
+    import os, sys
+    sys.path.insert(0, os.path.normpath(
+                           os.path.join(os.path.abspath(__file__), '..', '..', '..')))
+
+def generate_signature_dict():
+    timestamp = str(time.time())
+    token = str(uuid.uuid4())
+    signature = hmac.new(
+        key=settings.LISTSERV_API_KEY,
+        msg='{}{}'.format(timestamp, token),
+        digestmod=hashlib.sha256
+    ).hexdigest()
+    return {
+        'timestamp': timestamp,
+        'token': token,
+        'signature': signature
+    }
+
+# NOTE: this list contains only test accounts, and should be configured as
+#       world sendable
+list_address = 'canvas-206-3824@mg.dev.tlt.harvard.edu'
+
+# prep the base post body, which has no body params at all
+base_post = {
+    'sender': 'Integration Test <integrationtest@example.edu>',
+    'from': settings.NO_REPLY_ADDRESS,
+    'recipient': list_address,
+    'subject': 'blah',
+    'To': list_address,
+}
+base_post.update(generate_signature_dict())
+
+# generate the 4 "empty body cases"
+bodies = [
+    {},
+    {'body-html': '', 'body-plain': ''},
+    {'body-html': ''},
+    {'body-plain': ''},
+]
+posts = []
+for body in bodies:
+    post = copy.deepcopy(base_post)
+    post.update(body)
+    posts.append(post)
+
+# figure out which server to post to
+env_name = settings.ENV_NAME
+if env_name not in ('dev', 'qa', 'stage'):
+    env_name = 'dev'
+
+# do the posts 
+url = 'https://lti-emailer.%s.tlt.harvard.edu/mailgun/handle_mailing_list_email_route/' % env_name
+for post in posts:
+    resp = requests.post(url, data=post)
+
+    # we should get a 200 back indicating the mail has been accepted
+    resp.raise_for_status()
+
+# at this point, check the inbox of tlttest53@gmail.com for 4 emails with
+# empty bodies


### PR DESCRIPTION
Mailgun's API may not document it, but it won't send emails for you that have empty values for both the `body-plain` and `body-html` parameters.  But they will send emails with `'body-plain': ' '` (ie. a single space for a plain body).  So detect the empty body case, and work around it.

NOTE: this change includes a test script, since neither outlook nor gmail's web client would send emails with no body at all (they both supplied an empty html document for `body-html`).