### PR TITLE
tlt-1943: global mailing list settings

### DIFF
--- a/mailing_list/urls.py
+++ b/mailing_list/urls.py
@@ -9,5 +9,5 @@ urlpatterns = [
     url(r'^list_members/(?P<section_id>\d+)$', views.list_members, name='list_members'),
     url(r'^api/lists$', api.lists, name='api_lists'),
     url(r'^api/lists/(?P<mailing_list_id>\d+)/set_access_level$', api.set_access_level, name='api_lists_set_access_level'),
-    url(r'^api/course_settings/$', api.get_or_create_course_settings, name='api_get_or_create_course_settings'),
+    url(r'^api/course_settings/$', api.get_or_create_course_settings, name='api_course_settings'),
 ]


### PR DESCRIPTION
- fixes cache key, only updates database if row doesn't exist on GET
- simplifies new API endpoint name (for reverse lookups)
@eparker71 