### PR TITLE
tlt-2802: peg third-party package requirements to explicitly update them

### DIFF
--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -13,7 +13,7 @@ requests==2.12.1
 # flanker==0.4.38 requires cryptography but hasn't been updated in a long time
 cryptography==1.6
 
-# ng-httpsclient==0.4.2 requires pyopenssl but has no version specified
+# ndg-httpsclient==0.4.2 requires pyopenssl but has no version specified
 pyopenssl==16.2.0
 
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10#egg=canvas-python-sdk==0.10

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -1,14 +1,21 @@
 Django==1.8.16
-psycopg2==2.6.2
-ims_lti_py==0.6
-requests==2.12.1
-redis==2.10.5
-django-redis-cache==1.7.1
-hiredis==0.2.0
-django-cached-authentication-middleware==0.2.1
 django-angular==0.7.16
+django-cached-authentication-middleware==0.2.1
+django-redis-cache==1.7.1
 flanker==0.4.38
+hiredis==0.2.0
+ims_lti_py==0.6
 ndg-httpsclient==0.4.2
+psycopg2==2.6.2
+redis==2.10.5
+requests==2.12.1
+
+# flanker==0.4.38 requires cryptography but hasn't been updated in a long time
+cryptography==1.6
+
+# ng-httpsclient==0.4.2 requires pyopenssl but has no version specified
+pyopenssl==16.2.0
+
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10#egg=canvas-python-sdk==0.10
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.12.1#egg=django-icommons-common==1.12.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8


### PR DESCRIPTION
- flanker and ndg-httpsclient packages were not requiring recent versions of dependencies, causing runtime failures