### PR TITLE
tlt-2944: account delegation fix for users with multiple canvas accounts

### DIFF
--- a/lti_emailer/tests/test_canvas_api_client.py
+++ b/lti_emailer/tests/test_canvas_api_client.py
@@ -22,23 +22,40 @@ class GetAlternateEmailsForUserEmailTests(TestCase):
         self.assertEqual(mock_comm_channels.call_count, 0)
 
     def test_multiple_user_matches(self, mock_comm_channels, mock_users):
-        test_address = 'a@b.c'
+        """
+        should return de-duped set of email addresses for all matching users
+        """
+        test_address_a = 'a@b.c'
+        test_address_b = 'b@c.d'
         first_user_id = 1
         second_user_id = 2
+        first_user_cc_list = [
+            {'address': test_address_a, 'type': 'email', 'workflow_state': 'active'}]
+        second_user_cc_list = [
+            {'address': test_address_a, 'type': 'email', 'workflow_state': 'active'},
+            {'address': test_address_b, 'type': 'email', 'workflow_state': 'active'}]
+
         self.assertNotEqual(first_user_id, second_user_id)  # sanity check
 
         mock_users.return_value = [
-            {'id': first_user_id},
-            {'id': second_user_id}]
-        mock_comm_channels.return_value = []
+            {'id': first_user_id, 'email': test_address_a},
+            {'id': second_user_id, 'email': test_address_a}]
+        mock_comm_channels.side_effect = [
+            first_user_cc_list,
+            second_user_cc_list]
 
-        emails = get_alternate_emails_for_user_email(test_address)
+        emails = get_alternate_emails_for_user_email(test_address_a)
 
-        self.assertTrue(mock_comm_channels.called_once_with(first_user_id))
+        self.assertEqual(mock_comm_channels.call_count, 2)
         self.assertIsNotNone(emails)
-        self.assertEqual(len(emails), 0)
+        self.assertEqual(len(emails), 2)
+        self.assertIn(test_address_a, emails)
+        self.assertIn(test_address_b, emails)
 
     def test_valid_channel_filter(self, mock_comm_channels, mock_users):
+        """
+        should only return addresses for active email communication channels
+        """
         test_address = 'a@b.c'
         valid_address = 'd@e.f'
         invalid_address = 'g@h.i'
@@ -57,4 +74,29 @@ class GetAlternateEmailsForUserEmailTests(TestCase):
 
         self.assertIsNotNone(emails)
         self.assertEqual(len(emails), 1)
-        self.assertEqual(emails[0], valid_address)
+        self.assertIn(valid_address, emails)
+
+    def test_valid_user_filter(self, mock_comm_channels, mock_users):
+        """
+        should only look up users whose primary email matches email_address
+        argument
+        """
+        test_address_a = 'a@b.c'
+        test_address_b = 'b@c.d'
+        first_user_cc_list = [
+            {'address': test_address_a, 'type': 'email', 'workflow_state': 'active'}]
+        second_user_cc_list = [
+            {'address': test_address_b, 'type': 'email', 'workflow_state': 'active'}]
+
+        mock_users.return_value = [
+            {'id': 1, 'email': test_address_a},
+            {'id': 2, 'email': test_address_b}]
+        mock_comm_channels.side_effect = [
+            first_user_cc_list,
+            second_user_cc_list]
+
+        emails = get_alternate_emails_for_user_email(test_address_a)
+
+        self.assertIsNotNone(emails)
+        self.assertEqual(len(emails), 1)
+        self.assertIn(test_address_a, emails)


### PR DESCRIPTION
- when checking for valid delegate email address senders (envelope sender), consider all active email communication channels for canvas users with primary email address equal to 'from' as valid senders (formerly we denied sending when we found multiple canvas user accounts with the same primary email address)