### PR TITLE
Task/sapnamysore/tlt 2960/always deliver mail to sender

### DIFF
--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -17,6 +17,6 @@ cryptography==1.6
 pyopenssl==16.2.0
 
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10#egg=canvas-python-sdk==0.10
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.12.1#egg=django-icommons-common==1.12.1
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.16.2#egg=django-icommons-common==1.16.2
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.4#egg=django-auth-lti==1.2.4

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -294,6 +294,11 @@ def _handle_recipient(request, recipient, user_alt_email_cache):
                      subject, body_plain or body_html, message_id)
         return
 
+    # always send the email to the sender. Add sender to member_list(tlt-2960)
+    logger.debug(" Adding sender address  %s to the final list.",
+                 parsed_reply_to.address.lower())
+    member_addresses.union(parsed_reply_to.address.lower())
+
     # finally, we can send the email to the list
     member_addresses = list(member_addresses)
     logger.debug(u'Full list of recipients: %s', member_addresses)

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -294,7 +294,8 @@ def _handle_recipient(request, recipient, user_alt_email_cache):
                      subject, body_plain or body_html, message_id)
         return
 
-    # always send the email to the sender. Add sender to member_list(tlt-2960)
+    # always send the email to the sender. Add 'parsed_reply_to to the
+    # member_addresses set(tlt-2960)
     logger.debug(u'Adding parsed_reply_to(sender)address to the final list:%s.',
                  parsed_reply_to.address.lower())
     member_addresses.add(parsed_reply_to.address.lower())

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -145,7 +145,6 @@ def _handle_recipient(request, recipient, user_alt_email_cache):
             u'email subject, or check the super senders.', ml.canvas_course_id)
 
     member_addresses = set([m['address'].lower() for m in ml.members])
-    logger.debug(" length of member_addresses list :", len(member_addresses))
 
     # conditionally include staff addresses in the members list. If
     # always_mail_staff is true all staff will receive the email
@@ -296,9 +295,9 @@ def _handle_recipient(request, recipient, user_alt_email_cache):
         return
 
     # always send the email to the sender. Add sender to member_list(tlt-2960)
-    logger.debug(" Adding parsed_reply_to(sender)address to the final list.",
+    logger.debug(u'Adding parsed_reply_to(sender)address to the final list:%s.',
                  parsed_reply_to.address.lower())
-    member_addresses.union(parsed_reply_to.address.lower())
+    member_addresses.add(parsed_reply_to.address.lower())
 
     # finally, we can send the email to the list
     member_addresses = list(member_addresses)

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -296,8 +296,8 @@ def _handle_recipient(request, recipient, user_alt_email_cache):
 
     # always send the email to the sender. Add 'parsed_reply_to to the
     # member_addresses set(tlt-2960)
-    logger.debug(u'Adding parsed_reply_to(sender)address to the final list:%s.',
-                 parsed_reply_to.address.lower())
+    logger.debug(u'Adding parsed_reply_to (sender) address to the final '
+                 u'recipient list:%s.', parsed_reply_to.address.lower())
     member_addresses.add(parsed_reply_to.address.lower())
 
     # finally, we can send the email to the list

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -145,6 +145,7 @@ def _handle_recipient(request, recipient, user_alt_email_cache):
             u'email subject, or check the super senders.', ml.canvas_course_id)
 
     member_addresses = set([m['address'].lower() for m in ml.members])
+    logger.debug(" length of member_addresses list :", len(member_addresses))
 
     # conditionally include staff addresses in the members list. If
     # always_mail_staff is true all staff will receive the email
@@ -295,7 +296,7 @@ def _handle_recipient(request, recipient, user_alt_email_cache):
         return
 
     # always send the email to the sender. Add sender to member_list(tlt-2960)
-    logger.debug(" Adding sender address  %s to the final list.",
+    logger.debug(" Adding parsed_reply_to(sender)address to the final list.",
                  parsed_reply_to.address.lower())
     member_addresses.union(parsed_reply_to.address.lower())
 

--- a/mailgun/tests.py
+++ b/mailgun/tests.py
@@ -918,6 +918,215 @@ class RouteHandlerRegressionTests(TestCase):
         )
         ml.send_mail.assert_has_calls([send_mail_call, send_mail_call])
 
+    @patch('mailgun.route_handlers.SuperSender.objects.filter')
+    @patch('mailgun.route_handlers.CourseInstance.objects.get_primary_course_by_canvas_course_id')
+    @patch('mailgun.route_handlers.MailingList.objects.get_or_create_or_delete_mailing_list_by_address')
+    def test_sender_receives_copy_when_always_mail_staff_false(self, mock_ml_get, mock_ci_get, mock_ss_filter):
+        """
+        TLT-2960
+        Verifies that when the  course_settings is False, the Sender gets a copy
+        of the email, even if they are not in the section
+        """
+        members = [{'address': a} for a in ['student@example.edu', 'unittest@example.edu']]
+        cs = MagicMock(always_mail_staff=False)
+
+        ml = MagicMock(
+            canvas_course_id=123,
+            section_id=456,
+            teaching_staff_addresses={'teacher1@example.edu', 'teacher2@example.edu'},
+            members=members,
+            address='class-list@example.edu',
+            course_settings=cs
+        )
+        mock_ml_get.return_value = ml
+
+        # prep a CourseInstance mock
+        ci = MagicMock(course_instance_id=789,
+                       canvas_course_id=ml.canvas_course_id,
+                       short_title='Lorem For Beginners',
+                       course=MagicMock(school_id='colgsas'))
+        mock_ci_get.return_value = ci
+
+        # prep the SuperSender result
+        mock_ss_filter.return_value.values_list.return_value=[]
+
+        # prep the post body
+
+        # send mail to a canvas section
+        recipients = (['canvas-123-456@example.edu'])
+        post_body = {
+            'sender': 'Unit Test <teacher1@example.edu>',
+            'recipient': recipients,
+            'subject': 'blah',
+            'body-plain': 'blah blah',
+            'To': recipients
+        }
+        post_body.update(generate_signature_dict())
+
+        # prep the request
+        request = self.factory.post('/', post_body)
+        request.user = self.user
+
+        # run the view, verify success
+        response = handle_mailing_list_email_route(request)
+        self.assertEqual(response.status_code, 200)
+        send_mail_call = call(
+            u'Unit Test via Canvas',
+            u'teacher1@example.edu',
+            ['teacher1@example.edu', 'unittest@example.edu', 'student@example.edu'],#sender is included in email
+            u'[Lorem For Beginners] blah',
+            attachments=[],
+            html='',
+            inlines=[],
+            message_id=None,
+            original_cc_address=[],
+            original_to_address=[u'canvas-123-456@example.edu'],
+            text=u'blah blah'
+        )
+        ml.send_mail.assert_has_calls([send_mail_call])
+
+    @patch('mailgun.route_handlers.SuperSender.objects.filter')
+    @patch('mailgun.route_handlers.CourseInstance.objects.get_primary_course_by_canvas_course_id')
+    @patch('mailgun.route_handlers.MailingList.objects.get_or_create_or_delete_mailing_list_by_address')
+    def test_sender_in_section_and_receives_single_mail_when_always_mail_staff_false(self, mock_ml_get, mock_ci_get, mock_ss_filter):
+        """
+        TLT-2960
+
+        Verifies that when the course_settings is False and the sender is in the
+        section, the Sender  doesn't get a duplicate email
+        """
+        # prep a MailingList mock
+        members = [{'address': a} for a in ['teacher1@example.edu','unittest@example.edu', 'student@example.edu']]
+
+        cs = MagicMock(always_mail_staff= False)
+
+        ml = MagicMock(
+            canvas_course_id=123,
+            section_id=456,
+            teaching_staff_addresses={'teacher1@example.edu', 'teacher2@example.edu'},
+            members=members,
+            address='class-list@example.edu',
+            course_settings=cs
+        )
+        mock_ml_get.return_value = ml
+
+        # prep a CourseInstance mock
+        ci = MagicMock(course_instance_id=789,
+                       canvas_course_id=ml.canvas_course_id,
+                       short_title='Lorem For Beginners',
+                       course=MagicMock(school_id='colgsas'))
+        mock_ci_get.return_value = ci
+
+        # prep the SuperSender result
+        mock_ss_filter.return_value.values_list.return_value=[]
+
+        # prep the post body
+
+         # send mail to a canvas section
+        recipients = (['canvas-123-456@example.edu'])
+        post_body = {
+            'sender': 'Unit Test <teacher1@example.edu>',
+            'recipient': recipients,
+            'subject': 'blah',
+            'body-plain': 'blah blah',
+            'To': recipients
+        }
+        post_body.update(generate_signature_dict())
+
+        # prep the request
+        request = self.factory.post('/', post_body)
+        request.user = self.user
+
+        # run the view, verify success
+        response = handle_mailing_list_email_route(request)
+        self.assertEqual(response.status_code, 200)
+        send_mail_call = call(
+            u'Unit Test via Canvas',
+            u'teacher1@example.edu',
+            ['teacher1@example.edu', 'student@example.edu','unittest@example.edu'],
+            u'[Lorem For Beginners] blah',
+            attachments=[],
+            html='',
+            inlines=[],
+            message_id=None,
+            original_cc_address=[],
+            original_to_address=[u'canvas-123-456@example.edu'],
+            text=u'blah blah'
+        )
+        ml.send_mail.assert_has_calls([send_mail_call])
+
+    @patch('mailgun.route_handlers.SuperSender.objects.filter')
+    @patch('mailgun.route_handlers.CourseInstance.objects.get_primary_course_by_canvas_course_id')
+    @patch('mailgun.route_handlers.MailingList.objects.get_or_create_or_delete_mailing_list_by_address')
+    def test_email_to_multiple_sections_when_always_mail_staff_false(self, mock_ml_get, mock_ci_get, mock_ss_filter):
+        """
+        TLT-2960
+
+        When the  course_settings is False,  and multiple sections are
+        simultaneously emailed, that teh sender get2 multiple emails
+        """
+        # prep a MailingList mock, teacher not in section
+        members = [{'address': a} for a in ['unittest@example.edu', 'student@example.edu']]
+
+        cs = MagicMock(always_mail_staff= False)
+
+        ml = MagicMock(
+            canvas_course_id=123,
+            section_id=456,
+            teaching_staff_addresses={'teacher1@example.edu', 'teacher2@example.edu'},
+            members=members,
+            address='class-list@example.edu',
+            course_settings=cs
+        )
+        mock_ml_get.return_value = ml
+
+        # prep a CourseInstance mock
+        ci = MagicMock(course_instance_id=789,
+                       canvas_course_id=ml.canvas_course_id,
+                       short_title='Lorem For Beginners',
+                       course=MagicMock(school_id='colgsas'))
+        mock_ci_get.return_value = ci
+
+        # prep the SuperSender result
+        mock_ss_filter.return_value.values_list.return_value=[]
+
+        # prep the post body
+
+        # send mail to multiple  canvas sections
+        recipients = ', '.join(['canvas-123-456@example.edu', 'canvas-789-456@example.edu'])
+        post_body = {
+            'sender': 'Unit Test <teacher1@example.edu>',
+            'recipient': recipients,
+            'subject': 'blah',
+            'body-plain': 'blah blah',
+            'To': recipients
+        }
+        post_body.update(generate_signature_dict())
+        print(" post_body=", post_body)
+
+        # prep the request
+        request = self.factory.post('/', post_body)
+        request.user = self.user
+
+        # run the view, verify success
+        response = handle_mailing_list_email_route(request)
+        self.assertEqual(response.status_code, 200)
+        send_mail_call = call(
+            u'Unit Test via Canvas',
+            u'teacher1@example.edu',
+            ['teacher1@example.edu', 'student@example.edu','unittest@example.edu'],
+            u'[Lorem For Beginners] blah',
+            attachments=[],
+            html='',
+            inlines=[],
+            message_id=None,
+            original_cc_address=[],
+            original_to_address=[u'canvas-123-456@example.edu',u'canvas-789-456@example.edu'],
+            text=u'blah blah'
+        )
+        ml.send_mail.assert_has_calls([send_mail_call, send_mail_call])
+        self.assertEqual(ml.send_mail.call_count, 2)
+
     @patch('mailgun.route_handlers._send_bounce')
     @patch('mailgun.route_handlers.SuperSender.objects.filter')
     @patch('mailgun.route_handlers.CourseInstance.objects.get_primary_course_by_canvas_course_id')

--- a/mailgun/tests.py
+++ b/mailgun/tests.py
@@ -924,8 +924,8 @@ class RouteHandlerRegressionTests(TestCase):
     def test_sender_receives_copy_when_always_mail_staff_false(self, mock_ml_get, mock_ci_get, mock_ss_filter):
         """
         TLT-2960
-        Verifies that when the  course_settings is False, the Sender gets a copy
-        of the email, even if they are not in the section
+        Verifies that when the always_mail_staff course setting is False, the
+        Sender gets a copy of the email, even if they are not in the section
         """
         members = [{'address': a} for a in ['student@example.edu', 'unittest@example.edu']]
         cs = MagicMock(always_mail_staff=False)
@@ -973,7 +973,7 @@ class RouteHandlerRegressionTests(TestCase):
         send_mail_call = call(
             u'Unit Test via Canvas',
             u'teacher1@example.edu',
-            ['teacher1@example.edu', 'unittest@example.edu', 'student@example.edu'],#sender is included in email
+            ['teacher1@example.edu', 'unittest@example.edu', 'student@example.edu'],  #sender is included in email
             u'[Lorem For Beginners] blah',
             attachments=[],
             html='',
@@ -992,13 +992,13 @@ class RouteHandlerRegressionTests(TestCase):
         """
         TLT-2960
 
-        Verifies that when the course_settings is False and the sender is in the
-        section, the Sender  doesn't get a duplicate email
+        Verifies that when the always_mail_staff course setting is False and the
+        sender is in the section, the Sender doesn't get a duplicate email
         """
         # prep a MailingList mock
-        members = [{'address': a} for a in ['teacher1@example.edu','unittest@example.edu', 'student@example.edu']]
+        members = [{'address': a} for a in ['teacher1@example.edu', 'unittest@example.edu', 'student@example.edu']]
 
-        cs = MagicMock(always_mail_staff= False)
+        cs = MagicMock(always_mail_staff=False)
 
         ml = MagicMock(
             canvas_course_id=123,
@@ -1018,11 +1018,11 @@ class RouteHandlerRegressionTests(TestCase):
         mock_ci_get.return_value = ci
 
         # prep the SuperSender result
-        mock_ss_filter.return_value.values_list.return_value=[]
+        mock_ss_filter.return_value.values_list.return_value = []
 
         # prep the post body
 
-         # send mail to a canvas section
+        # send mail to a canvas section
         recipients = (['canvas-123-456@example.edu'])
         post_body = {
             'sender': 'Unit Test <teacher1@example.edu>',
@@ -1043,7 +1043,7 @@ class RouteHandlerRegressionTests(TestCase):
         send_mail_call = call(
             u'Unit Test via Canvas',
             u'teacher1@example.edu',
-            ['teacher1@example.edu', 'student@example.edu','unittest@example.edu'],
+            ['teacher1@example.edu', 'student@example.edu', 'unittest@example.edu'],
             u'[Lorem For Beginners] blah',
             attachments=[],
             html='',
@@ -1062,13 +1062,13 @@ class RouteHandlerRegressionTests(TestCase):
         """
         TLT-2960
 
-        When the  course_settings is False,  and multiple sections are
-        simultaneously emailed, that teh sender get2 multiple emails
+        When the always_mail_staff course setting is False, and multiple
+        sections are simultaneously emailed, the sender gets multiple emails
         """
         # prep a MailingList mock, teacher not in section
         members = [{'address': a} for a in ['unittest@example.edu', 'student@example.edu']]
 
-        cs = MagicMock(always_mail_staff= False)
+        cs = MagicMock(always_mail_staff=False)
 
         ml = MagicMock(
             canvas_course_id=123,
@@ -1088,7 +1088,7 @@ class RouteHandlerRegressionTests(TestCase):
         mock_ci_get.return_value = ci
 
         # prep the SuperSender result
-        mock_ss_filter.return_value.values_list.return_value=[]
+        mock_ss_filter.return_value.values_list.return_value = []
 
         # prep the post body
 
@@ -1194,7 +1194,7 @@ class RouteHandlerRegressionTests(TestCase):
         mock_ci_get.return_value = ci
 
         # prep the SuperSender result
-        mock_ss_filter.return_value.values_list.return_value=[]
+        mock_ss_filter.return_value.values_list.return_value = []
 
         # prep the post body
         post_body = {


### PR DESCRIPTION
Fix for [TLT-2960](https://jira.huit.harvard.edu/browse/TLT-2960):  Always have the sender receive a copy of their email no matter which global setting is chosen. Adding parsed_reply_to to the final list.
Includes some  unit tests