### PR TITLE
tlt-2959: tooltip placement fix for member list link

### DIFF
--- a/mailing_list/templates/mailing_list/_mailing_list_details.html
+++ b/mailing_list/templates/mailing_list/_mailing_list_details.html
@@ -18,6 +18,7 @@
         rel="tooltip"
         title=""
         data-original-title="Go to list of names, emails, and roles"
+        data-placement="right"
         data-toggle="tooltip"
         href="{{ ml.listMembersUrl(list) }}"><ng-pluralize count="list.members_count"
                     when="{'0': 'No members', 'one': '1 member', 'other': '{} members'}"></ng-pluralize></a>)


### PR DESCRIPTION
Admin page course and section member list links now show hover tooltip on right-hand side instead of above, to avoid an issue where the left edge of the iframe (in Canvas) was cutting off the tooltip.

An example of what it looks like with this fix:
![screen shot 2017-01-24 at 4 26 20 pm](https://cloud.githubusercontent.com/assets/8975317/22267535/1f81deae-e252-11e6-8472-470c87b9e61a.png)

