### PR TITLE
TLT-3354 LTI Emailer mapping of permissions to new roles

### DIFF
--- a/mailing_list/migrations/0014_add_new_permissions_for_roles.py
+++ b/mailing_list/migrations/0014_add_new_permissions_for_roles.py
@@ -3,7 +3,8 @@ import itertools
 
 from django.db import migrations
 
-# Adds new roles to the lti_school_permissions table and removes all isites migration permission records.
+# Adds new roles to the lti_permissions table with the same permissions that are mapped over from their equivalent
+# previous role. There are 4 roles that are by default, not allowed in all schools.
 
 NEW_ROLES_MAP = {
     'Course Head': ['Head Instructor', 'Course Director'],


### PR DESCRIPTION
Google sheet containing the lti_permissions table after migration has been applied

https://docs.google.com/spreadsheets/d/1DadhZ04X6JmuvP3AjO7csGhNiLBhVp48joQabwPK9jk/edit#gid=916758549

See story for more details
https://jira.huit.harvard.edu/browse/TLT-3354