### PR TITLE
Task/sapnamysore/tlt 3370/fix error msg

### DIFF
--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -20,6 +20,7 @@ pyopenssl==16.2.0
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10.2#egg=canvas-python-sdk==0.10.2
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.33.2#egg=django-icommons-common==1.33.2
 
-#git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8
--e ../django-icommons-ui
+#git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.34#egg=django-icommons-common[async]==1.10.34
+#temporarily point to branch
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@task/sapnamysore/tlt-3370/fix-styles-error-msg#egg=django-icommons-ui
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.4#egg=django-auth-lti==1.2.4

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -20,5 +20,6 @@ pyopenssl==16.2.0
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10.2#egg=canvas-python-sdk==0.10.2
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.33.2#egg=django-icommons-common==1.33.2
 
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8
+#git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8
+-e ../django-icommons-ui
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.4#egg=django-auth-lti==1.2.4

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -19,9 +19,5 @@ pyopenssl==16.2.0
 
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10.2#egg=canvas-python-sdk==0.10.2
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.33.2#egg=django-icommons-common==1.33.2
-
-#git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8
-#temporarily point to branch
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@task/sapnamysore/tlt-3370/fix-styles-error-msg#egg=django-icommons-ui
-
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v1.5.3#egg=django-icommons-ui==1.5.3
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.4#egg=django-auth-lti==1.2.4

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -20,7 +20,8 @@ pyopenssl==16.2.0
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10.2#egg=canvas-python-sdk==0.10.2
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.33.2#egg=django-icommons-common==1.33.2
 
-#git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.10.34#egg=django-icommons-common[async]==1.10.34
+#git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v0.9.8#egg=django-icommons-ui==0.9.8
 #temporarily point to branch
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@task/sapnamysore/tlt-3370/fix-styles-error-msg#egg=django-icommons-ui
+
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v1.2.4#egg=django-auth-lti==1.2.4


### PR DESCRIPTION
This PR is pulling in the change in icommons-ui  to the current 'Unauthorized' message as per AC #3 in https://jira.huit.harvard.edu/browse/TLT-3370 

Lti_emailer  is using this branch and is deployed on dev and the fix can be tested in this course https://canvas.dev.tlt.harvard.edu/courses/5809/external_tools/143  logged in as test12@mcelroy.org

Note that the qa version of the tool still has the old message





