### PR TITLE
Changes to links and removal of unused  text as outlined in TLT-3522 …

### DIFF
--- a/mailing_list/templates/mailing_list/admin_index.html
+++ b/mailing_list/templates/mailing_list/admin_index.html
@@ -43,7 +43,7 @@ $(document).ready(function(){
             message from an email address that is listed in your Canvas user
             account or your message will not be delivered.
               <a target="_blank"
-                 href="https://wiki.harvard.edu/confluence/display/canvas/Course+Emailer "
+                 href=" https://harvard.service-now.com/ithelp?id=kb_article&sys_id=c061a82f37ad7a809aa163d2b3990e1c"
                  class="lti-tooltip"
                  rel="tooltip"
                  data-toggle="tooltip"
@@ -200,7 +200,7 @@ $(document).ready(function(){
                   <p class="caption" ng-show="ml.hasCourseEmailList()">
                     This course site includes enrollment from two or more courses.
                     <a target="_blank"
-                     href="https://wiki.harvard.edu/confluence/pages/viewpage.action?pageId=189597345"
+                     href="https://harvard.service-now.com/ithelp?id=kb_article&sys_id=aa9a5b70db602bc096ab5682ca9619ef"
                      class="lti-tooltip"
                      rel="tooltip"
                      data-toggle="tooltip"
@@ -211,7 +211,6 @@ $(document).ready(function(){
                   </p>
                   <p class="caption">
                     The lists below reflect enrollments from the Registrar’s office and will be updated automatically.
-                    Any email sent to a list will be delivered to members of that list <b>and to all staff in the course.</b>
                   </p>
                 </div>
                 <div  ng-repeat="list in ml.enrollmentSectionLists">


### PR DESCRIPTION
…and TLT-3523.

Deployed to dev.  A course setup with Course emailer: https://canvas.dev.tlt.harvard.edu/courses/3761/external_tools/143