### PR TITLE
Feature/handle batv senders

### DIFF
--- a/batv_test.py
+++ b/batv_test.py
@@ -1,0 +1,23 @@
+# Import smtplib for the actual sending function
+import smtplib
+
+# Import the email modules we'll need
+from email.mime.text import MIMEText
+
+from_addr = 'colin_murtaugh@harvard.edu'
+to_addr = 'canvas-4998@mg.dev.tlt.harvard.edu'
+
+# envelope_addr = from_addr
+envelope_addr = 'prvs=764a7a4cd={}'.format(from_addr)
+
+body = 'This is a message for testing the LTI emailer. Envelope address: {}'.format(envelope_addr)
+
+msg = MIMEText(body)
+msg['From'] = from_addr
+msg['To'] = to_addr
+msg['Subject'] = 'Test message'
+
+
+s = smtplib.SMTP('mailhub.harvard.edu')
+s.sendmail(envelope_addr, [to_addr], msg.as_string())
+s.quit()

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -5,7 +5,7 @@ django-redis-cache==1.7.1
 flanker==0.4.38
 hiredis==0.2.0
 ims_lti_py==0.6
-ndg-httpsclient==0.4.2
+ndg-httpsclient==0.5.1
 psycopg2==2.7.3.1
 redis==2.10.5
 requests==2.12.1
@@ -15,7 +15,7 @@ cx_oracle==5.3
 cryptography==1.6
 
 # ndg-httpsclient==0.4.2 requires pyopenssl but has no version specified
-pyopenssl>=17.5.0
+pyopenssl==18.0.0
 
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10.2#egg=canvas-python-sdk==0.10.2
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.33.2#egg=django-icommons-common==1.33.2

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -15,7 +15,7 @@ cx_oracle==5.3
 cryptography==1.6
 
 # ndg-httpsclient==0.4.2 requires pyopenssl but has no version specified
-pyopenssl==16.2.0
+pyopenssl>=17.5.0
 
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10.2#egg=canvas-python-sdk==0.10.2
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.33.2#egg=django-icommons-common==1.33.2

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -5,17 +5,13 @@ django-redis-cache==1.7.1
 flanker==0.4.38
 hiredis==0.2.0
 ims_lti_py==0.6
-ndg-httpsclient==0.5.1
 psycopg2==2.7.3.1
 redis==2.10.5
-requests==2.12.1
+requests==2.20.0
 cx_oracle==5.3
 
 # flanker==0.4.38 requires cryptography but hasn't been updated in a long time
 cryptography==1.6
-
-# ndg-httpsclient==0.4.2 requires pyopenssl but has no version specified
-pyopenssl==18.0.0
 
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v0.10.2#egg=canvas-python-sdk==0.10.2
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v1.33.2#egg=django-icommons-common==1.33.2

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -413,7 +413,7 @@ def _get_attachments_inlines(request):
 
 def _remove_batv_prefix(sender_address):
     # Strip BATV prefix from the envelope-sender address if present
-    batv_pattern = '^prvs=[^=]+=(.+)'
+    batv_pattern = '^\w+=+[^=]+=+(.+)'
     try:
         batv_address = re.match(batv_pattern, sender_address)
         if batv_address:

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -422,7 +422,7 @@ def _remove_batv_prefix(sender_address):
             logger.warning('sender address ({}) has BATV prefix, removing: {}'.format(batv_address.group(0), batv_address.group(1)))
             return batv_address.group(1)
     except Exception:
-        logger.exception('error while removing BATV prefix ({}) from {}'.format(batv_pattern, sender_address))
+        logger.exception('error while removing BATV prefix ({}) from {}/{}'.format(batv_pattern, sender_address, type(sender_address)))
 
     # otherwise just return the original address
     return sender_address

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -69,11 +69,9 @@ def handle_mailing_list_email_route(request):
     from_ = address.parse(request.POST.get('from'))
     message_id = request.POST.get('Message-Id')
     recipients = set(address.parse_list(request.POST.get('recipient')))
-    sender = address.parse(request.POST.get('sender'))
+    sender = address.parse(_remove_batv_prefix(request.POST.get('sender')))
     subject = request.POST.get('subject')
     user_alt_email_cache = CommChannelCache()
-
-    sender = _remove_batv_prefix(sender)
 
     logger.info(u'Handling Mailgun mailing list email from %s (sender %s) to '
                 u'%s, subject %s, message id %s',

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -415,14 +415,14 @@ def _get_attachments_inlines(request):
 
 def _remove_batv_prefix(sender_address):
     # Strip BATV prefix from the envelope-sender address if present
+    batv_pattern = '^prvs=[^=]+=(.+)'
     try:
-        batv_pattern = '^prvs=[^=]+=(.+)'
         batv_address = re.match(batv_pattern, sender_address)
         if batv_address:
             logger.warning('sender address ({}) has BATV prefix, removing: {}'.format(batv_address.group(0), batv_address.group(1)))
             return batv_address.group(1)
     except Exception:
-        logger.exception('error while removing BATV prefix from {}'.format(sender_address))
+        logger.exception('error while removing BATV prefix ({}) from {}'.format(batv_pattern, sender_address))
 
     # otherwise just return the original address
     return sender_address


### PR DESCRIPTION
This PR addresses TLT-3509: some email senders use "Bounce Address Tag Validation", which means that the address in the envelope sender field has a prefix added that looks like "prvs=<hash>=". 
This PR makes the Emailer work with these addresses by stripping off the prefix before doing any comparison with the list members, etc. 
The PR also includes a script that I used to test to make sure that the change works as expected. 
Finally -- I also updated the version of `pyopenssl` to address a security vulnerability (CVE-2018-1000807).