### PR TITLE
Updates to work with the latest flanker

### DIFF
--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -13,7 +13,7 @@ from django.template.loader import get_template
 from django.utils.decorators import available_attrs
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
-from flanker.addresslib import address
+from flanker.addresslib import address as addresslib_address
 
 from icommons_common.models import CourseInstance
 from lti_emailer.canvas_api_client import (
@@ -66,10 +66,10 @@ def handle_mailing_list_email_route(request):
     '''
     logger.debug(u'Full mailgun post: %s', request.POST)
 
-    from_ = address.parse(request.POST.get('from'))
+    from_ = addresslib_address.parse(request.POST.get('from'))
     message_id = request.POST.get('Message-Id')
-    recipients = set(address.parse_list(request.POST.get('recipient')))
-    sender = address.parse(_remove_batv_prefix(request.POST.get('sender')))
+    recipients = set(addresslib_address.parse_list(request.POST.get('recipient')))
+    sender = addresslib_address.parse(_remove_batv_prefix(request.POST.get('sender')))
     subject = request.POST.get('subject')
     user_alt_email_cache = CommChannelCache()
 
@@ -111,12 +111,12 @@ def _handle_recipient(request, recipient, user_alt_email_cache):
     attachments, inlines = _get_attachments_inlines(request)
     body_html = request.POST.get('body-html', '')
     body_plain = request.POST.get('body-plain', '')
-    cc_list = address.parse_list(request.POST.get('Cc'))
-    parsed_from = address.parse(request.POST.get('from'))
+    cc_list = addresslib_address.parse_list(request.POST.get('Cc'))
+    parsed_from = addresslib_address.parse(request.POST.get('from'))
     message_id = request.POST.get('Message-Id')
     sender = request.POST.get('sender')
     subject = request.POST.get('subject')
-    to_list = address.parse_list(request.POST.get('To'))
+    to_list = addresslib_address.parse_list(request.POST.get('To'))
 
     logger.debug(u'Handling recipient %s, from %s, subject %s, message id %s',
                  recipient, sender, subject, message_id)
@@ -188,7 +188,7 @@ def _handle_recipient(request, recipient, user_alt_email_cache):
 
     # if we want to check email addresses against the sender, we need to parse
     # out the address from the display name.
-    parsed_sender = address.parse(sender)
+    parsed_sender = addresslib_address.parse(sender)
     sender_address = parsed_sender.address.lower()
     from_address = parsed_from.address.lower() if parsed_from else None
 

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -264,7 +264,7 @@ class MailingList(models.Model):
         logger.debug(u'in send_mail: sender_address=%s, to_address=%s, '
                      u'mailing_list.address=%s ',
                      sender_address, to_address, self.address)
-        mailing_list_address = addresslib_address.parse('{} {}'.format(sender_display_name, self.address))
+        mailing_list_address = addresslib_address.parse(u'{} {}'.format(sender_display_name, self.address))
         listserv_client.send_mail(
             mailing_list_address.full_spec(), sender_address, to_address,
             subject, text, html, original_to_address, original_cc_address,

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -265,7 +265,6 @@ class MailingList(models.Model):
                      u'mailing_list.address=%s ',
                      sender_address, to_address, self.address)
         mailing_list_address = addresslib_address.parse('{} {}'.format(sender_display_name, self.address))
-        # mailing_list_address.display_name = sender_display_name
         listserv_client.send_mail(
             mailing_list_address.full_spec(), sender_address, to_address,
             subject, text, html, original_to_address, original_cc_address,

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db import models
 from django.utils import timezone
-from flanker import addresslib
+from flanker.addresslib import address as addresslib_address
 
 from lti_emailer import canvas_api_client
 from mailgun.listserv_client import MailgunClient as ListservClient
@@ -264,8 +264,8 @@ class MailingList(models.Model):
         logger.debug(u'in send_mail: sender_address=%s, to_address=%s, '
                      u'mailing_list.address=%s ',
                      sender_address, to_address, self.address)
-        mailing_list_address = addresslib.address.parse(self.address)
-        mailing_list_address.display_name = sender_display_name
+        mailing_list_address = addresslib_address.parse('{} {}'.format(sender_display_name, self.address))
+        # mailing_list_address.display_name = sender_display_name
         listserv_client.send_mail(
             mailing_list_address.full_spec(), sender_address, to_address,
             subject, text, html, original_to_address, original_cc_address,


### PR DESCRIPTION
PR includes:
* Fix for setting the display_name (can't set it directly anymore; need to include the display name in the string to parse)
* `import address as addresslib_address` to avoid collisions
