### PR TITLE
TLT-3994: Remove option for world-access

### DIFF
--- a/mailing_list/static/mailing_list/js/app.js
+++ b/mailing_list/static/mailing_list/js/app.js
@@ -69,13 +69,6 @@
         section: 'all members of this section and all staff can email each other; students and guests <strong>can</strong> send and reply to this mailing list.'
       }
     },{
-      id: 'everyone',
-      name: {class: 'World Access:', section: 'World Access:'},
-      description: {
-        class: 'anyone can send and reply to this mailing list.',
-        section: 'anyone can send and reply to this mailing list.'
-      }
-    },{
       id: 'readonly',
       name: {class: 'Disabled:', section: 'Disabled:'},
       description: {


### PR DESCRIPTION
Per [TLT-3994](https://jira.huit.harvard.edu/browse/TLT-3994), this PR removes the "World Access" option from LTI Emailer. 

This branch has been deployed to both Dev and QA. For an example of this update, see [this course](https://canvas.dev.tlt.harvard.edu/courses/171/external_tools/3) and click on the gear icon on the right-hand side of the "Email Entire Course" section. You will no longer see the "World Access" option within the list.