### PR TITLE
Fix recipient header

### DIFF
--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==2.2.4
+Django==2.2.24
 django-angular==2.2.1
 django-cached-authentication-middleware==0.2.2
 django-redis-cache==2.0.0

--- a/lti_emailer/requirements/local.txt
+++ b/lti_emailer/requirements/local.txt
@@ -1,11 +1,11 @@
 # local environment requirements
 
 #includes the base.txt requirements needed in all environments
--r base.txt 
- 
+-r base.txt
+
 # below are requirements specific to the local environment
 
-django-debug-toolbar==1.9
+django-debug-toolbar==1.11.1
 django-sslserver==0.21
 mock==3.0.5
 pep8==1.7.0
@@ -24,4 +24,3 @@ git+ssh://git@github.com/Harvard-University-iCommons/selenium_common.git@v1.4.3#
 # icommons_common and into ccsw, work around the circular dependency by calling
 # out the ccsw dependency here.
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v2.0#egg=django-canvas-course-site-wizard==2.0
-

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -60,7 +60,10 @@ class MailgunClient(object):
         # these are prefixed with h: so that mailgun doesn't think we want it
         # to send copies to these addresses as well.
         if original_to_address:
-            payload['h:To'] = original_to_address
+            payload['h:To'] = '%recipient.original_to_address%'
+            recip_var_dict = {'original_to_address': original_to_address}
+        else:
+            recip_var_dict = {}
         if original_cc_address:
             payload['h:Cc'] = original_cc_address
 
@@ -69,7 +72,7 @@ class MailgunClient(object):
         # doesn't include the whole list in the to: field, per
         #   https://documentation.mailgun.com/user_manual.html#batch-sending
         if not isinstance(to_address, str):
-            recipient_variables = {e: {} for e in to_address}
+            recipient_variables = {e: recip_var_dict for e in to_address}
             payload['recipient-variables'] = json.dumps(recipient_variables)
 
         # We need to replace non-ascii characters in attachment filenames

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -61,7 +61,7 @@ class MailgunClient(object):
         # to send copies to these addresses as well.
         if original_to_address:
             payload['h:To'] = '%recipient.original_to_address%'
-            recip_var_dict = {'original_to_address': original_to_address}
+            recip_var_dict = {'original_to_address': ','.join(original_to_address)}
         else:
             recip_var_dict = {}
         if original_cc_address:


### PR DESCRIPTION
Mailgun recently (Nov. 2021?) released a reimplemented version of their API which behaves slightly differently than the old one did. The impact to us is that messages sent through the emailer are received with a `To` header that contains the string `%recipient%` rather than the actual recipient address. 

Mailgun support suggested a change to the way that we set the `To` header in order to get the old behavior back. 

Essentially the change is to use Mailgun's `user-variables` feature to populate the `To` header with the mailing-list address. Mailgun will always add the actual recipient's individual email address, so we end up with the desired header: `users-address@harvard.edu, list-address@coursemail.harvard.edu`. 