### PR TITLE
Upgrade to Django 3.2 and upgrade build/base images to v3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ data/
 selenium_tests/reports/
 secure.*
 parameters.*
+# files generated via `runserver_plus` CLI command
+*.crt
+*.key

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # syntax=docker/dockerfile:experimental
 
-FROM 482956169056.dkr.ecr.us-east-1.amazonaws.com/uw/python-postgres-build:v0.5 as build
+FROM 482956169056.dkr.ecr.us-east-1.amazonaws.com/uw/python-postgres-build:v3.10 as build
 COPY lti_emailer/requirements/*.txt /code/
-RUN --mount=type=ssh,id=build_ssh_key ./python_venv/bin/pip3 install gunicorn && ./python_venv/bin/pip3 install -r aws.txt
+RUN --mount=type=ssh,id=build_ssh_key ./python_venv/bin/pip install gunicorn && ./python_venv/bin/pip install -r aws.txt
 COPY . /code/
 RUN chmod a+x /code/docker-entrypoint.sh
 
-FROM 482956169056.dkr.ecr.us-east-1.amazonaws.com/uw/python-postgres-base:v0.5
+FROM 482956169056.dkr.ecr.us-east-1.amazonaws.com/uw/python-postgres-base:v3.10
 COPY --from=build /code /code/
 ENV PYTHONUNBUFFERED 1
 WORKDIR /code

--- a/README.md
+++ b/README.md
@@ -19,19 +19,19 @@ We use the [Mailgun API](https://documentation.mailgun.com/ "Mailgun API") to se
 
 ## Local dev setup
 
-After getting all your db connection stuff setup in the secure.py, access the 
-vagrant shell and bring up the postgres shell via `psql`. At the shell prompt:
+Bootstrapping a local Python development environment on your host machine for testing (make sure `USE_PYTHON_VERSION` corresponds to the current Python version used by the `Dockerfile`):
 
-    alter role vagrant with password '(your secure.py default db password)';
+```sh
+USE_PYTHON_VERSION="3.10.4"
+VENV_DIR=".venv"
+pyenv install --skip-existing ${USE_PYTHON_VERSION}
+rm -Rf "${VENV_DIR}" && PYENV_VERSION=${USE_PYTHON_VERSION} python -m venv "${VENV_DIR}"
+. "${VENV_DIR}"/bin/activate && pip install --upgrade pip wheel
+. "${VENV_DIR}"/bin/activate && pip install -r lti_emailer/requirements/local.txt
+```
 
-Then, back in the vagrant shell:
+Running it from your host machine, if libraries and a Python environment are installed locally:
 
-    python manage.py init_db
-    python manage.py migrate
-
-If you're running via runsslserver and testing in Chrome, you'll need to 'bless'
-the local SSL connection in Chrome by first bringing up the tool_config
-(e.g. `https://localhost:8000/tool_config`) in a separate window and explicitly
-allowing the connection.
-
-And because it accesses the coursemanager, don't forget the VPN.
+```sh
+ENV=dev DJANGO_SETTINGS_MODULE=lti_emailer.settings.local python manage.py runserver_plus --cert-file cert.crt
+```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-./python_venv/bin/python3 manage.py migrate                  # Apply database migrations
-./python_venv/bin/python3 manage.py collectstatic --noinput  # Collect static files
+./python_venv/bin/python manage.py migrate                  # Apply database migrations
+./python_venv/bin/python manage.py collectstatic --noinput  # Collect static files
 
 # Start Gunicorn processes
 echo Starting Gunicorn.

--- a/lti_emailer/canvas_api_client.py
+++ b/lti_emailer/canvas_api_client.py
@@ -12,7 +12,6 @@ from canvas_sdk.methods import (
     accounts,
     communication_channels)
 from canvas_sdk.methods.users import list_users_in_account
-from canvas_sdk.methods.enrollments import list_enrollments_sections
 
 from canvas_sdk.utils import get_all_list_data
 from canvas_sdk.exceptions import CanvasAPIError

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -1,21 +1,22 @@
-Django==2.2.25
-django-angular==2.2.1
+Django==3.2.13
+# django-angular==2.2.1
 django-cached-authentication-middleware==0.2.2
-django-redis-cache==2.0.0
-flanker==0.9.0
-hiredis==1.0.0
-psycopg2==2.8.3
-redis==3.3.8
-requests==2.26.0
-cx_oracle==7.2.2
-django-storages==1.7.2
+django-redis-cache==3.0.1
+flanker==0.9.11
+hiredis==2.0.0
+psycopg2==2.9.3
+redis==3.5.3
+requests==2.28.1
+cx_oracle==8.3.0
+django-storages==1.12.3
 splunk_handler==3.0.0
-python-json-logger==2.0.2
-django-allow-cidr==0.3.1
-django-watchman==1.2.0
+python-json-logger==2.0.4
+django-allow-cidr==0.5.0
+django-watchman==1.3.0
 
+git+ssh://git@github.com/Harvard-University-iCommons/django-angular.git@v2.3#egg=django-angular==2.3
 git+ssh://git@github.com/penzance/canvas_python_sdk.git@v1.2.0#egg=canvas-python-sdk==1.2.0
-git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v2.6#egg=django-icommons-common==2.6
+git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v3.0#egg=django-icommons-common==3.0
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1#egg=django-icommons-ui==2.1
-git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.0.1#egg=django-auth-lti==2.0.1
+git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0#egg=django-auth-lti==2.1.0
 git+https://github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.6#egg=django-ssm-parameter-store==0.6

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -1,5 +1,4 @@
 Django==3.2.13
-# django-angular==2.2.1
 django-cached-authentication-middleware==0.2.2
 django-redis-cache==3.0.1
 flanker==0.9.11

--- a/lti_emailer/requirements/local.txt
+++ b/lti_emailer/requirements/local.txt
@@ -4,18 +4,20 @@
 -r base.txt
 
 # below are requirements specific to the local environment
+django-debug-toolbar==3.5
+mock==4.0.3
+pep8==1.7.1
+flake8==4.0.1
 
-django-debug-toolbar==1.11.1
-django-sslserver==0.21
-mock==3.0.5
-pep8==1.7.0
-flake8==3.7.9
+django-extensions==3.1.5 # provides `runserver_plus` local dev server
+pyOpenSSL==22.0.0 # dependency for django-extensions
+Werkzeug==2.0.3 # dependency for django-extensions
 
 # selenium
-PyVirtualDisplay==0.2
-ddt==1.1.0
-selenium==2.53.6
-xlrd==1.0.0
+PyVirtualDisplay==3.0
+ddt==1.5.0
+selenium==4.3.0
+xlrd==2.0.1
 git+ssh://git@github.com/Harvard-University-iCommons/selenium_common.git@v1.4.3#egg=selenium-common==1.4.3
 
 
@@ -23,4 +25,4 @@ git+ssh://git@github.com/Harvard-University-iCommons/selenium_common.git@v1.4.3#
 # until ccsw gets its own proper project, and we move the delete command out of
 # icommons_common and into ccsw, work around the circular dependency by calling
 # out the ccsw dependency here.
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v2.0#egg=django-canvas-course-site-wizard==2.0
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-course-site-wizard.git@v3.0#egg=django-canvas-course-site-wizard==3.0

--- a/lti_emailer/settings/local.py
+++ b/lti_emailer/settings/local.py
@@ -5,7 +5,7 @@ ALLOWED_HOSTS = ['*']
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 
-INSTALLED_APPS += ['debug_toolbar', 'sslserver']
+INSTALLED_APPS += ['debug_toolbar', 'django_extensions']
 MIDDLEWARE += ['debug_toolbar.middleware.DebugToolbarMiddleware']
 
 # For Django Debug Toolbar:

--- a/mailgun/decorators.py
+++ b/mailgun/decorators.py
@@ -6,7 +6,6 @@ import time
 from functools import wraps
 
 from django.conf import settings
-from django.utils.decorators import available_attrs
 from django.shortcuts import redirect
 from django.urls import reverse_lazy
 
@@ -16,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def authenticate(redirect_url=reverse_lazy('mailgun:auth_error')):
     def decorator(view_func):
-        @wraps(view_func, assigned=available_attrs(view_func))
+        @wraps(view_func)
         def _wrapped_view(request, *args, **kwargs):
             try:
                 timestamp = request.POST['timestamp']

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -7,7 +7,7 @@ from functools import wraps
 
 from django.conf import settings
 from django.core.cache import cache
-from django.http import HttpResponse, JsonResponse
+from django.http import JsonResponse
 from django.template.loader import get_template
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -9,7 +9,6 @@ from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpResponse, JsonResponse
 from django.template.loader import get_template
-from django.utils.decorators import available_attrs
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 from flanker.addresslib import address as addresslib_address
@@ -31,7 +30,7 @@ listserv_client = ListservClient()
 
 def handle_exceptions():
     def decorator(view_func):
-        @wraps(view_func, assigned=available_attrs(view_func))
+        @wraps(view_func)
         def inner(request, *args, **kwargs):
             try:
                 return view_func(request, *args, **kwargs)

--- a/mailing_list/api.py
+++ b/mailing_list/api.py
@@ -4,7 +4,6 @@ import json
 from django.conf import settings
 from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required
-from django.utils import timezone
 from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
 

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -4,14 +4,12 @@ import re
 from django.conf import settings
 from django.core.cache import cache
 from django.db import models
-from django.utils import timezone
 from flanker.addresslib import address as addresslib_address
 
 from lti_emailer import canvas_api_client
 from mailgun.listserv_client import MailgunClient as ListservClient
-from icommons_common.models import CourseInstance
 
-from mailing_list.utils import is_course_crosslisted, get_section_sis_enrollment_status
+from mailing_list.utils import get_section_sis_enrollment_status
 
 logger = logging.getLogger(__name__)
 

--- a/mailing_list/views.py
+++ b/mailing_list/views.py
@@ -13,8 +13,6 @@ from lti_permissions.decorators import lti_permission_required
 from lti_emailer.canvas_api_client import get_enrollments, get_section, get_course
 from mailing_list.models import MailingList
 
-from mailing_list.utils import is_course_crosslisted
-
 from icommons_common.canvas_api.helpers import enrollments as canvas_api_helpers_enrollments
 
 logger = logging.getLogger(__name__)
@@ -37,7 +35,7 @@ def admin_index(request):
         course_name = course['course_code']
     else:
         course_name = canvas_course_id
-        
+
     logger.info("Rendering mailing_list admin_index view for user %s",
                 logged_in_user_id)
     return render(request, 'mailing_list/admin_index.html', {'course_name': course_name, 'build_info': build_info})


### PR DESCRIPTION
Resolves [TLT-4257](https://jira.huit.harvard.edu/browse/TLT-4257) (Django 3.2 upgrade) and [TLT-4241](https://jira.huit.harvard.edu/browse/TLT-4241) (base/build image upgrades).

This PR:
- Upgrades the app to Django 3.2.
- Updates the Dockerfile to use v3.10 of the base and build images.
- Replaces `django-sslserver` with `django-extensions` since the former is incompatible with Django 3.x.
- Removes references to a Django API for Python 2 compatibility that is no longer supported in Django 3.x (`available_attrs`).
- Cleans up unused imports.
- Updates the `README` to reflect changes to local development.

Testing:

These changes have been deployed to Dev and QA. Testing involved manually exercising various parts of the app (e.g. changing the mailing list permissions, sending an email to the class roster, etc.).