### PR TITLE
Task/haydn9000/tlt 4303/lti emailer attachment missing error

### DIFF
--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -94,11 +94,8 @@ class MailgunClient(object):
             files.extend([('attachment', (replace_non_ascii(f.name), f, f.content_type)) for f in attachments])
         if inlines:
             files.extend([('inline', (replace_non_ascii(f.name), f, f.content_type)) for f in inlines])
-        
         if eml_attachments:
-            payload.update(eml_attachments)
-
-        logger.info(f'Payload data: ', extra=payload)
+            files.extend([('inline', (replace_non_ascii(key), value)) for key, value in eml_attachments.items()])
 
         with ApiRequestTimer(logger, 'POST', api_url, payload) as timer:
             response = requests.post(api_url, auth=(self.api_user, self.api_key),

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -98,6 +98,8 @@ class MailgunClient(object):
         if eml_attachments:
             payload.update(eml_attachments)
 
+        logger.info(f'Payload data: ', extra=payload)
+
         with ApiRequestTimer(logger, 'POST', api_url, payload) as timer:
             response = requests.post(api_url, auth=(self.api_user, self.api_key),
                                      data=payload, files=files)

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -96,7 +96,7 @@ class MailgunClient(object):
             files.extend([('inline', (replace_non_ascii(f.name), f, f.content_type)) for f in inlines])
         if encapsulated_msg_att:
             content_type = 'message/rfc822'
-            files.extend([('inline', (replace_non_ascii(value[0]), value[1], content_type)) for key, value in encapsulated_msg_att.items()])
+            files.extend([('inline', (replace_non_ascii(value[0]+'.eml'), value[1], content_type)) for key, value in encapsulated_msg_att.items()])
 
         with ApiRequestTimer(logger, 'POST', api_url, payload) as timer:
             response = requests.post(api_url, auth=(self.api_user, self.api_key),

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -95,8 +95,7 @@ class MailgunClient(object):
         if inlines:
             files.extend([('inline', (replace_non_ascii(f.name), f, f.content_type)) for f in inlines])
         if encapsulated_msg_att:
-            content_type = 'message/rfc822'
-            files.extend([('attachment', (replace_non_ascii(value[0]+'.eml'), value[1], content_type))
+            files.extend([('attachment', (replace_non_ascii(value[0]+'.eml'), value[1]))
                          for key, value in encapsulated_msg_att.items()])
 
         with ApiRequestTimer(logger, 'POST', api_url, payload) as timer:

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -30,11 +30,14 @@ class MailgunClient(object):
     def send_mail(self, list_address, from_address, to_address, subject='',
                   text='', html='', original_to_address=None,
                   original_cc_address=None, attachments=None, inlines=None,
-                  message_id=None):
+                  eml_attachments=None, message_id=None):
         api_url = "%s%s/messages" % (settings.LISTSERV_API_URL,
                                      settings.LISTSERV_DOMAIN)
 
-        logger.debug(f'send_mail called with list_address={list_address} from_address={from_address} to_address={to_address} subject={subject} original_to_address={original_to_address} original_cc_address={original_cc_address} message_id={message_id}')
+        logger.debug(f'send_mail called with list_address={list_address} ' 
+                     f'from_address={from_address} to_address={to_address} '
+                     f'subject={subject} original_to_address={original_to_address} '
+                     f'original_cc_address={original_cc_address} message_id={message_id}')
 
         payload = {
             'from': list_address,
@@ -91,6 +94,9 @@ class MailgunClient(object):
             files.extend([('attachment', (replace_non_ascii(f.name), f, f.content_type)) for f in attachments])
         if inlines:
             files.extend([('inline', (replace_non_ascii(f.name), f, f.content_type)) for f in inlines])
+        
+        if eml_attachments:
+            payload.update(eml_attachments)
 
         with ApiRequestTimer(logger, 'POST', api_url, payload) as timer:
             response = requests.post(api_url, auth=(self.api_user, self.api_key),

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -96,7 +96,8 @@ class MailgunClient(object):
             files.extend([('inline', (replace_non_ascii(f.name), f, f.content_type)) for f in inlines])
         if encapsulated_msg_att:
             content_type = 'message/rfc822'
-            files.extend([('inline', (replace_non_ascii(value[0]+'.eml'), value[1], content_type)) for key, value in encapsulated_msg_att.items()])
+            files.extend([('attachment', (replace_non_ascii(value[0]+'.eml'), value[1], content_type))
+                         for key, value in encapsulated_msg_att.items()])
 
         with ApiRequestTimer(logger, 'POST', api_url, payload) as timer:
             response = requests.post(api_url, auth=(self.api_user, self.api_key),

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -30,7 +30,7 @@ class MailgunClient(object):
     def send_mail(self, list_address, from_address, to_address, subject='',
                   text='', html='', original_to_address=None,
                   original_cc_address=None, attachments=None, inlines=None,
-                  eml_attachments=None, message_id=None):
+                  encapsulated_msg_att=None, message_id=None):
         api_url = "%s%s/messages" % (settings.LISTSERV_API_URL,
                                      settings.LISTSERV_DOMAIN)
 
@@ -94,8 +94,9 @@ class MailgunClient(object):
             files.extend([('attachment', (replace_non_ascii(f.name), f, f.content_type)) for f in attachments])
         if inlines:
             files.extend([('inline', (replace_non_ascii(f.name), f, f.content_type)) for f in inlines])
-        if eml_attachments:
-            files.extend([('inline', (replace_non_ascii(key), value)) for key, value in eml_attachments.items()])
+        if encapsulated_msg_att:
+            content_type = 'message/rfc822'
+            files.extend([('inline', (replace_non_ascii(value[0]), value[1], content_type)) for key, value in encapsulated_msg_att.items()])
 
         with ApiRequestTimer(logger, 'POST', api_url, payload) as timer:
             response = requests.post(api_url, auth=(self.api_user, self.api_key),

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -419,24 +419,10 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
             attachment_content = ''
             try:
                 attachment_content = request.POST.get(attachment_name, '')
-            except Exception as e:
-                logger.info("Failed to retrieve .eml attachment")
+                attachments.append(file_)
+            except Exception:
+                logger.info(f'file type: {type(file_)} attachment_content: {attachment_content}')
 
-            logger.info(f'file type: {type(file_)} attachment_content: {attachment_content}')
-
-            if attachment_content:
-                fp = tempfile.TemporaryFile()
-                fp.write(bytes(attachment_content, encoding='utf-8'))
-                attachments.append(fp)
-                fp.close()
-                logger.info(f'attachments after saving temp file {attachments}')
-                
-
-
-
-
-
-            else:
                 logger.exception('Mailgun POST claimed to have %s attachments, '
                                 'but %s is missing',
                                 attachment_count, attachment_name)
@@ -453,18 +439,19 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
                             }
                             )
 
-                _send_bounce('mailgun/email/bounce_back_attachments_missing.html',
-                            sender, recipient.full_spec(), subject,
-                            body_plain or body_html, message_id)
+                # _send_bounce('mailgun/email/bounce_back_attachments_missing.html',
+                #             sender, recipient.full_spec(), subject,
+                #             body_plain or body_html, message_id)
 
-                raise HttpResponseException(JsonResponse(
-                        {
-                            'message': 'Attachment {} missing from POST'.format(
-                                            attachment_name),
-                            'success': False,
-                        },
-                        status=400))
-                        
+                # raise HttpResponseException(JsonResponse(
+                #         {
+                #             'message': 'Attachment {} missing from POST'.format(
+                #                             attachment_name),
+                #             'success': False,
+                #         },
+                #         status=400))
+             
+
         if attachment_name in attachment_name_to_cid:
             file_.cid = attachment_name_to_cid[attachment_name]
             file_.name = file_.name.replace(' ', '_')

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -416,16 +416,18 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
         try:
             file_ = request.FILES[attachment_name]
         except KeyError:
-            attachment_content = request.POST.get(attachment_name, '')
+            try:
+                attachment_content = request.POST.get(attachment_name, '')
+            except Exception as e:
+                logger.info("Failed to retrieve .eml attachment")
 
             logger.info("attachment_content", extra=attachment_content)
 
             if attachment_content:
-                fp = tempfile.TemporaryFile()
-                fp.write(attachment_content)
-                attachments.append(fp)
-                fp.close()
-
+                # fp = tempfile.TemporaryFile()
+                # fp.write(attachment_content)
+                # attachments.append(fp)
+                # fp.close()
                 logger.info("attachments after saving temp file", extra=attachments)
 
 

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -126,7 +126,7 @@ def _handle_recipient(request, recipient, user_alt_email_cache):
     logger.debug('Handling recipient %s, from %s, subject %s, message id %s',
                  recipient, sender, subject, message_id)
     logger.info(f'attachments: {attachments}, inlines: {inlines}, '
-                f'encapsulated_msg_att: {encapsulated_msg_att}, '
+                f'encapsulated_msg_att_count: {len(encapsulated_msg_att)}, '
                 f'attachments_total_size: {attachments_size} byte(s), '
                 f'from: {sender}, message id: {message_id}')
 

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -426,7 +426,7 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
         else:
             attachments.append(file_)
 
-        attachments_size += file_.size
+        attachments_size += len(file_)
 
     return attachments, inlines, attachments_size
 

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -425,11 +425,10 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
             logger.info(f'file type: {type(file_)} attachment_content: {attachment_content}')
 
             if attachment_content:
-                # fp = tempfile.TemporaryFile()
-                # fp.write(attachment_content)
-                # attachments.append(fp)
-                # fp.close()
-                attachments.append(attachment_name)
+                fp = tempfile.TemporaryFile()
+                fp.write(attachment_content)
+                attachments.append(fp)
+                fp.close()
                 logger.info(f'attachments after saving temp file {attachments}')
                 
 

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -391,6 +391,10 @@ def _handle_recipient(request, recipient, user_alt_email_cache):
 def _get_attachments_inlines(request, sender, recipient, subject, body_plain, body_html, message_id):
     attachments = []
     inlines = []
+    # encapsulated_msg_att is for "message/rfc822" attachments (learn more here: 
+    # https://learn.microsoft.com/en-us/previous-versions/office/developer/exchange-server-2010/aa494204(v=exchg.140))
+    # Key is attachment-x, name from Mailgun and value is tuple of subject 
+    # use as attachment name, and contents of attachment
     encapsulated_msg_att = {}
     attachments_size = 0
 

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -423,7 +423,7 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
                 name = name[:name.find('\r')+len('\r')]
             encapsulated_msg_att[attachment_name] = (name, eml_content)
 
-            attachments_size += sys.getsizeof(encapsulated_msg_att[attachment_name])
+            attachments_size += sys.getsizeof(encapsulated_msg_att[attachment_name][1])
             continue
         elif request.FILES.get(attachment_name):
             file_ = request.FILES[attachment_name]

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -426,7 +426,7 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
 
             if attachment_content:
                 fp = tempfile.TemporaryFile()
-                fp.write(bytes(attachment_content))
+                fp.write(bytes(attachment_content, encoding='utf-8'))
                 attachments.append(fp)
                 fp.close()
                 logger.info(f'attachments after saving temp file {attachments}')

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -416,13 +416,17 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
         try:
             file_ = request.FILES[attachment_name]
         except KeyError:
-            attachment_content = request.POST.get(attachment_name, '{}')
+            attachment_content = request.POST.get(attachment_name, '')
+
+            logger.info("attachment_content", extra=attachment_content)
 
             if attachment_content:
                 fp = tempfile.TemporaryFile()
                 fp.write(attachment_content)
                 attachments.append(fp)
                 fp.close()
+
+                logger.info("attachments after saving temp file", extra=attachments)
 
 
 

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -422,7 +422,7 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
             except Exception as e:
                 logger.info("Failed to retrieve .eml attachment")
 
-            logger.info(f'attachment_content {attachment_content}')
+            logger.info(f'file type: {type(file_)} attachment_content: {attachment_content}')
 
             if attachment_content:
                 # fp = tempfile.TemporaryFile()

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -407,7 +407,7 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
                          'forwarding all files as attachments.')
         content_id_map = {}
     attachment_name_to_cid = {v: k.strip('<>') for k, v in content_id_map.items()}
-    logger.debug('Attachment name to cid: %s', attachment_name_to_cid)
+    logger.info('Attachment name to cid: %s', attachment_name_to_cid)
 
     for n in range(1, attachment_count + 1):
         attachment_name = 'attachment-{}'.format(n)

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -410,8 +410,7 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
     attachment_name_to_cid = {v: k.strip('<>') for k, v in content_id_map.items()}
     logger.info('Attachment name to cid: %s', attachment_name_to_cid)
 
-    for n in range(1, attachment_count + 1):
-        attachment_name = 'attachment-{}'.format(n)
+    for attachment_name in request.FILES.keys():
         try:
             file_ = request.FILES[attachment_name]
         except KeyError:

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -408,7 +408,7 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
                          'forwarding all files as attachments.')
         content_id_map = {}
     attachment_name_to_cid = {v: k.strip('<>') for k, v in content_id_map.items()}
-    logger.info('Attachment name to cid: %s', attachment_name_to_cid)
+    logger.debug('Attachment name to cid: %s', attachment_name_to_cid)
 
     for n in range(1, attachment_count + 1):
         attachment_name = 'attachment-{}'.format(n)

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -416,19 +416,20 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
         try:
             file_ = request.FILES[attachment_name]
         except KeyError:
+            attachment_content = ''
             try:
                 attachment_content = request.POST.get(attachment_name, '')
             except Exception as e:
                 logger.info("Failed to retrieve .eml attachment")
 
-            logger.info("attachment_content", extra=attachment_content)
+            logger.info("attachment_content", extra={attachment_content})
 
             if attachment_content:
                 # fp = tempfile.TemporaryFile()
                 # fp.write(attachment_content)
                 # attachments.append(fp)
                 # fp.close()
-                logger.info("attachments after saving temp file", extra=attachments)
+                logger.info("attachments after saving temp file", extra={attachments})
 
 
 

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -422,14 +422,14 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
             except Exception as e:
                 logger.info("Failed to retrieve .eml attachment")
 
-            logger.info("attachment_content", extra={attachment_content})
+            logger.info(f'attachment_content {attachment_content}')
 
             if attachment_content:
                 # fp = tempfile.TemporaryFile()
                 # fp.write(attachment_content)
                 # attachments.append(fp)
                 # fp.close()
-                logger.info("attachments after saving temp file", extra={attachments})
+                logger.info(f'attachments after saving temp file {attachments}')
 
 
 

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -418,9 +418,17 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
                              'but %s is missing',
                              attachment_count, attachment_name)
 
-            logger.info(f'Sending mailing list bounce back email to {sender} '
-                        f'for mailing list {recipient} because Mailgun POST claimed to have '
-                        f'{attachment_count} attachments but {attachment_name} is missing')
+            logger.info(f'Sent bounce back email to {sender} for mailing list {recipient} '
+                        f'because Mailgun POST claimed to have {attachment_count} '
+                        f'attachments but {attachment_name} is missing',
+                        extra={
+                            'sender': sender,
+                            'recipient': recipient,
+                            'content_id_map': content_id_map,
+                            'attachment_count': attachment_count,
+                            'attachment_name': attachment_name
+                        }
+                        )
 
             _send_bounce('mailgun/email/bounce_back_attachments_missing.html',
                          sender, recipient.full_spec(), subject,

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -355,7 +355,7 @@ def _handle_recipient(request, recipient, user_alt_email_cache):
 
     # make sure inline images actually show up inline, since fscking
     # mailgun won't let us specify the cid on post.  see their docs at
-    #   https://documentation.mailgun.com/user_manual.html#sending-via-api
+    # https://documentation.mailgun.com/en/latest/user_manual.html#sending-via-api
     # where they explain that they use the inlined file's name attribute
     # as the content-id.
     if inlines:
@@ -426,7 +426,7 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
                     attachments.append(fp)
                     logger.debug(
                         f'attachment name: {attachment_name}, '
-                        f'type: {type(fp)}, '
+                        f'type: {type(attachments[-1])}, '
                         f'attachment_content: {attachment_content}'
                     )
                     fp.close()

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -389,7 +389,6 @@ def _handle_recipient(request, recipient, user_alt_email_cache):
 def _get_attachments_inlines(request, sender, recipient, subject, body_plain, body_html, message_id):
     attachments = []
     inlines = []
-    eml_attachments = []
     attachments_size = 0
 
     try:
@@ -426,7 +425,7 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
         else:
             attachments.append(file_)
 
-        attachments_size += len(file_)
+        # attachments_size += len(file_)
 
     return attachments, inlines, attachments_size
 

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -426,7 +426,7 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
 
             if attachment_content:
                 fp = tempfile.TemporaryFile()
-                fp.write(attachment_content)
+                fp.write(bytes(attachment_content))
                 attachments.append(fp)
                 fp.close()
                 logger.info(f'attachments after saving temp file {attachments}')

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -420,7 +420,7 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
             word = 'Subject: '
             if word in eml_content:
                 name = eml_content[eml_content.find(word)+len(word): ]
-                name = name[:name.find('\r')+len('\r')]
+                name = name[:name.find('\r')]
             encapsulated_msg_att[attachment_name] = (name, eml_content)
 
             attachments_size += sys.getsizeof(encapsulated_msg_att[attachment_name][1])

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -428,7 +428,7 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
         else:
             attachments.append(file_)
 
-        attachments_size += file_
+        attachments_size += file_.size
 
     return attachments, inlines, eml_attachments, attachments_size
 

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -419,9 +419,8 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
             attachment_content = ''
             try:
                 attachment_content = request.POST.get(attachment_name, '')
-                attachments.append(file_)
             except Exception:
-                logger.info(f'file type: {type(file_)} attachment_content: {attachment_content}')
+                logger.info(f'attachment type: {type(file_)} attachment_content: {attachment_content}')
 
                 logger.exception('Mailgun POST claimed to have %s attachments, '
                                 'but %s is missing',
@@ -439,19 +438,18 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
                             }
                             )
 
-                # _send_bounce('mailgun/email/bounce_back_attachments_missing.html',
-                #             sender, recipient.full_spec(), subject,
-                #             body_plain or body_html, message_id)
+                _send_bounce('mailgun/email/bounce_back_attachments_missing.html',
+                            sender, recipient.full_spec(), subject,
+                            body_plain or body_html, message_id)
 
-                # raise HttpResponseException(JsonResponse(
-                #         {
-                #             'message': 'Attachment {} missing from POST'.format(
-                #                             attachment_name),
-                #             'success': False,
-                #         },
-                #         status=400))
+                raise HttpResponseException(JsonResponse(
+                        {
+                            'message': 'Attachment {} missing from POST'.format(
+                                            attachment_name),
+                            'success': False,
+                        },
+                        status=400))
              
-
         if attachment_name in attachment_name_to_cid:
             file_.cid = attachment_name_to_cid[attachment_name]
             file_.name = file_.name.replace(' ', '_')

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -429,7 +429,9 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
                 # fp.write(attachment_content)
                 # attachments.append(fp)
                 # fp.close()
+                attachments.append(attachment_name)
                 logger.info(f'attachments after saving temp file {attachments}')
+                
 
 
 

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -420,43 +420,45 @@ def _get_attachments_inlines(request, sender, recipient, subject, body_plain, bo
             attachment_content = ''
             try:
                 attachment_content = request.POST.get(attachment_name, '')
-            except Exception:
+
                 if attachment_content:
                     eml_attachments.append(attachment_content)
+                    
                     logger.debug(
                         f'attachment name: {attachment_name}, '
                         f'type: {type(attachments[-1])}, '
                         f'attachment_content: {eml_attachments}'
                     )
-                else:
-                    logger.exception('Mailgun POST claimed to have %s attachments, '
-                                    'but %s is missing',
-                                    attachment_count, attachment_name)
+                    continue
+            except Exception:
+                logger.exception('Mailgun POST claimed to have %s attachments, '
+                                 'but %s is missing',
+                                 attachment_count, attachment_name)
 
-                    logger.info(f'Sent bounce back email to {sender} for mailing list {recipient} '
-                                f'because Mailgun POST claimed to have {attachment_count} '
-                                f'attachments but {attachment_name} is missing',
-                                extra={
-                                    'sender': sender,
-                                    'recipient': recipient,
-                                    'content_id_map': content_id_map,
-                                    'attachment_count': attachment_count,
-                                    'attachment_name': attachment_name
-                                }
-                                )
+                logger.info(f'Sent bounce back email to {sender} for mailing list {recipient} '
+                            f'because Mailgun POST claimed to have {attachment_count} '
+                            f'attachments but {attachment_name} is missing',
+                            extra={
+                                'sender': sender,
+                                'recipient': recipient,
+                                'content_id_map': content_id_map,
+                                'attachment_count': attachment_count,
+                                'attachment_name': attachment_name
+                            }
+                            )
 
-                    _send_bounce('mailgun/email/bounce_back_attachments_missing.html',
-                                sender, recipient.full_spec(), subject,
-                                body_plain or body_html, message_id)
+                _send_bounce('mailgun/email/bounce_back_attachments_missing.html',
+                             sender, recipient.full_spec(), subject,
+                             body_plain or body_html, message_id)
 
-                    raise HttpResponseException(JsonResponse(
-                            {
-                                'message': 'Attachment {} missing from POST'.format(
-                                                attachment_name),
-                                'success': False,
-                            },
-                            status=400))
-             
+                raise HttpResponseException(JsonResponse(
+                    {
+                        'message': 'Attachment {} missing from POST'.format(
+                            attachment_name),
+                        'success': False,
+                    },
+                    status=400))
+
         if attachment_name in attachment_name_to_cid:
             file_.cid = attachment_name_to_cid[attachment_name]
             file_.name = file_.name.replace(' ', '_')

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -450,6 +450,8 @@ def get_eml_attachments(request, eml_attachments, attachment_count, attachment_n
                 attachment_content = request.POST.get(attachment_name)
                 if attachment_content:
                     eml_attachments.append(attachment_content)
+
+                    body_html += attachment_content
             except KeyError:
                 log_attachment_error_warn_user(attachment_count, attachment_name, sender, recipient, subject,
                                                body_plain, body_html, message_id, content_id_map)

--- a/mailgun/templates/mailgun/email/bounce_back_attachments_missing.html
+++ b/mailgun/templates/mailgun/email/bounce_back_attachments_missing.html
@@ -1,0 +1,7 @@
+{% extends 'mailgun/email/base.html' %}
+
+{% block content %}
+Your email message could not be sent. There appears to be an attachment issue. 
+Please create a ticket with info about the attachments you may be trying to send. 
+Thank you!
+{% endblock content %}

--- a/mailgun/templates/mailgun/email/bounce_back_attachments_missing.html
+++ b/mailgun/templates/mailgun/email/bounce_back_attachments_missing.html
@@ -1,7 +1,6 @@
 {% extends 'mailgun/email/base.html' %}
 
 {% block content %}
-Your email message could not be sent. There appears to be an attachment issue. 
-Please create a ticket with info about the attachments you may be trying to send. 
-Thank you!
+Your email message could not be sent. There appears to be a problem with one or more attachments.
+If possible, please post the file(s) to your Canvas site and link to them there instead of attaching the files to your email message. 
 {% endblock content %}

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -260,7 +260,7 @@ class MailingList(models.Model):
     def send_mail(self, sender_display_name, sender_address, to_address,
                   subject='', text='', html='', original_to_address=None,
                   original_cc_address=None, attachments=None, inlines=None,
-                  message_id=None):
+                  eml_attachments=None, message_id=None):
         logger.debug('in send_mail: sender_address=%s, to_address=%s, '
                      'mailing_list.address=%s ',
                      sender_address, to_address, self.address)
@@ -268,7 +268,7 @@ class MailingList(models.Model):
         listserv_client.send_mail(
             mailing_list_address.full_spec(), sender_address, to_address,
             subject, text, html, original_to_address, original_cc_address,
-            attachments, inlines, message_id
+            attachments, inlines, eml_attachments, message_id
         )
         cache_key = settings.CACHE_KEY_MESSAGE_HANDLED_BY_MESSAGE_ID_AND_RECIPIENT % (message_id, to_address)
         cache.set(cache_key, True,

--- a/mailing_list/models.py
+++ b/mailing_list/models.py
@@ -260,7 +260,7 @@ class MailingList(models.Model):
     def send_mail(self, sender_display_name, sender_address, to_address,
                   subject='', text='', html='', original_to_address=None,
                   original_cc_address=None, attachments=None, inlines=None,
-                  eml_attachments=None, message_id=None):
+                  encapsulated_msg_att=None, message_id=None):
         logger.debug('in send_mail: sender_address=%s, to_address=%s, '
                      'mailing_list.address=%s ',
                      sender_address, to_address, self.address)
@@ -268,7 +268,7 @@ class MailingList(models.Model):
         listserv_client.send_mail(
             mailing_list_address.full_spec(), sender_address, to_address,
             subject, text, html, original_to_address, original_cc_address,
-            attachments, inlines, eml_attachments, message_id
+            attachments, inlines, encapsulated_msg_att, message_id
         )
         cache_key = settings.CACHE_KEY_MESSAGE_HANDLED_BY_MESSAGE_ID_AND_RECIPIENT % (message_id, to_address)
         cache.set(cache_key, True,


### PR DESCRIPTION
* Emails sent as attachments will no longer cause missing attachment errors and will be sent.
* If attachment missing errors occur, bounce email will be sent to sender.
* Logging for missing attachments and bounce email.
