### PR TITLE
Hotfix v2.8.1

### DIFF
--- a/lti_emailer/requirements/local.txt
+++ b/lti_emailer/requirements/local.txt
@@ -8,6 +8,7 @@ django-debug-toolbar==3.5
 mock==4.0.3
 pep8==1.7.1
 flake8==4.0.1
+oracledb==1.1.1
 
 django-extensions==3.1.5 # provides `runserver_plus` local dev server
 pyOpenSSL==22.0.0 # dependency for django-extensions

--- a/lti_emailer/settings/local.py
+++ b/lti_emailer/settings/local.py
@@ -1,4 +1,10 @@
 from .base import *
+
+import sys
+import oracledb
+oracledb.version = "8.3.0"
+sys.modules["cx_Oracle"] = oracledb
+
 from logging.config import dictConfig
 
 ALLOWED_HOSTS = ['*']

--- a/mailing_list/templates/mailing_list/base_list_details.html
+++ b/mailing_list/templates/mailing_list/base_list_details.html
@@ -24,6 +24,10 @@
     <script src="https://static.tlt.harvard.edu/shared/bootstrap-datepicker/js/bootstrap-datepicker.js"></script>
     <script src="https://static.tlt.harvard.edu/shared/listjs/list.min.js"></script>
     {% include 'django_auth_lti/resource_link_id.html' %}
+    <script src="https://static.tlt.harvard.edu/shared/angular-1.5.2/angular.min.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/angular-1.5.2/angular-sanitize.min.js"></script>
+    <script src="https://static.tlt.harvard.edu/shared/angular-1.5.2/angular-animate.min.js"></script>
+    <script src="{% static 'djng/js/django-angular.js' %}"></script>
     <script src="{% static 'mailing_list/js/app.js' %}"></script>
     {% block js %}{% endblock js %}
     <title>Course Emailer</title>


### PR DESCRIPTION
Adds missing Angular script imports to template
Adds oracledb to local settings and requirements

This fixes the display message in the "View members" page that should only be displayed in non-prod environments. Without the imports, the message is being displayed in all environments