### PR TITLE
Task/haydn9000/tlt 4371/update to use canvas sdk library

### DIFF
--- a/lti_emailer/canvas_api_client.py
+++ b/lti_emailer/canvas_api_client.py
@@ -1,7 +1,7 @@
 """
-Utility methods for working with canvas_sdk which add a caching layer to the Canvas API calls.
+Utility methods for working with canvas_python_sdk which add a caching layer to the Canvas API calls.
 
-TODO: Incorporate this caching layer into canvas_sdk. Punting on this for now to limit collateral concerns.
+TODO: Incorporate this caching layer into canvas_python_sdk. Punting on this for now to limit collateral concerns.
 """
 import logging
 

--- a/lti_emailer/canvas_api_client.py
+++ b/lti_emailer/canvas_api_client.py
@@ -1,7 +1,7 @@
 """
-Utility methods for working with canvas_python_sdk which add a caching layer to the Canvas API calls.
+Utility methods for working with canvas_sdk which add a caching layer to the Canvas API calls.
 
-TODO: Incorporate this caching layer into canvas_python_sdk. Punting on this for now to limit collateral concerns.
+TODO: Incorporate this caching layer into canvas_sdk. Punting on this for now to limit collateral concerns.
 """
 import logging
 
@@ -16,8 +16,8 @@ from canvas_sdk.methods.users import list_users_in_account
 from canvas_sdk.utils import get_all_list_data
 from canvas_sdk.exceptions import CanvasAPIError
 
-from icommons_common.canvas_utils import SessionInactivityExpirationRC
-from icommons_common.canvas_api.helpers import (
+from canvas_api.canvas_utils import SessionInactivityExpirationRC
+from canvas_api.helpers import (
     courses as canvas_api_helper_courses,
     sections as canvas_api_helper_sections)
 

--- a/lti_emailer/canvas_api_client.py
+++ b/lti_emailer/canvas_api_client.py
@@ -16,7 +16,7 @@ from canvas_sdk.methods.users import list_users_in_account
 from canvas_sdk.utils import get_all_list_data
 from canvas_sdk.exceptions import CanvasAPIError
 
-from canvas_api.canvas_utils import SessionInactivityExpirationRC
+from canvas_sdk.client import RequestContext
 from canvas_api.helpers import (
     courses as canvas_api_helper_courses,
     sections as canvas_api_helper_sections)
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 CACHE_KEY_COMM_CHANNELS_BY_CANVAS_USER_ID = "comm-channels-by-canvas-user-id_%s"
 CACHE_KEY_USER_IN_ACCOUNT_BY_SEARCH_TERM = "user-in-account-{}-by-search-term-{}"
-SDK_CONTEXT = SessionInactivityExpirationRC(**settings.CANVAS_SDK_SETTINGS)
+SDK_CONTEXT = RequestContext(**settings.CANVAS_SDK_SETTINGS)
 TEACHING_STAFF_ENROLLMENT_TYPES = ['TeacherEnrollment', 'TaEnrollment', 'DesignerEnrollment']
 USER_ATTRIBUTES_TO_COPY = ['email', 'name', 'sortable_name']
 

--- a/lti_emailer/management/commands/report_user_primary_email.py
+++ b/lti_emailer/management/commands/report_user_primary_email.py
@@ -11,11 +11,11 @@ from canvas_sdk.utils import get_all_list_data
 from canvas_sdk.methods.courses import list_users_in_course_users
 from canvas_sdk.exceptions import CanvasAPIError
 
-from canvas_api.canvas_utils import SessionInactivityExpirationRC
+from canvas_sdk.client import RequestContext
 from icommons_common.models import Person
 
 
-SDK_CONTEXT = SessionInactivityExpirationRC(**settings.CANVAS_SDK_SETTINGS)
+SDK_CONTEXT = RequestContext(**settings.CANVAS_SDK_SETTINGS)
 logger = logging.getLogger(__name__)
 
 

--- a/lti_emailer/management/commands/report_user_primary_email.py
+++ b/lti_emailer/management/commands/report_user_primary_email.py
@@ -11,7 +11,7 @@ from canvas_sdk.utils import get_all_list_data
 from canvas_sdk.methods.courses import list_users_in_course_users
 from canvas_sdk.exceptions import CanvasAPIError
 
-from icommons_common.canvas_utils import SessionInactivityExpirationRC
+from canvas_api.canvas_utils import SessionInactivityExpirationRC
 from icommons_common.models import Person
 
 

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==3.2.15
+Django==3.2.16
 django-cached-authentication-middleware==0.2.2
 django-redis-cache==3.0.1
 flanker==0.9.11

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -14,7 +14,7 @@ django-allow-cidr==0.5.0
 django-watchman==1.3.0
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-angular.git@v2.3#egg=django-angular==2.3
-git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@task/haydn9000/TLT-4356/add-canvas-api-helper-modules#egg=canvas-python-sdk
+git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@v1.3#egg=canvas-python-sdk==1.3
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v3.0#egg=django-icommons-common==3.0
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1#egg=django-icommons-ui==2.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0#egg=django-auth-lti==2.1.0

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -14,8 +14,7 @@ django-allow-cidr==0.5.0
 django-watchman==1.3.0
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-angular.git@v2.3#egg=django-angular==2.3
-# git+ssh://git@github.com/penzance/canvas_python_sdk.git@v1.2.0#egg=canvas-python-sdk==1.2.0
-git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@c444a33850c7b275e547935c3fb7a24542ea0e0f#egg=canvas-python-sdk==c444a33850c7b275e547935c3fb7a24542ea0e0f
+git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@task/haydn9000/TLT-4356/add-canvas-api-helper-modules#egg=canvas-python-sdk
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v3.0#egg=django-icommons-common==3.0
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1#egg=django-icommons-ui==2.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0#egg=django-auth-lti==2.1.0

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -14,7 +14,8 @@ django-allow-cidr==0.5.0
 django-watchman==1.3.0
 
 git+ssh://git@github.com/Harvard-University-iCommons/django-angular.git@v2.3#egg=django-angular==2.3
-git+ssh://git@github.com/penzance/canvas_python_sdk.git@v1.2.0#egg=canvas-python-sdk==1.2.0
+# git+ssh://git@github.com/penzance/canvas_python_sdk.git@v1.2.0#egg=canvas-python-sdk==1.2.0
+git+ssh://git@github.com/Harvard-University-iCommons/canvas_python_sdk.git@c444a33850c7b275e547935c3fb7a24542ea0e0f#egg=canvas-python-sdk==c444a33850c7b275e547935c3fb7a24542ea0e0f
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@v3.0#egg=django-icommons-common==3.0
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1#egg=django-icommons-ui==2.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0#egg=django-auth-lti==2.1.0

--- a/lti_emailer/settings/base.py
+++ b/lti_emailer/settings/base.py
@@ -326,7 +326,6 @@ CANVAS_SDK_SETTINGS = {
     'base_api_url': CANVAS_URL + '/api',
     'max_retries': 3,
     'per_page': 40,
-    'session_inactivity_expiration_time_secs': 50,
 }
 
 ICOMMONS_COMMON = {

--- a/mailing_list/views.py
+++ b/mailing_list/views.py
@@ -13,7 +13,7 @@ from lti_permissions.decorators import lti_permission_required
 from lti_emailer.canvas_api_client import get_enrollments, get_section, get_course
 from mailing_list.models import MailingList
 
-from icommons_common.canvas_api.helpers import enrollments as canvas_api_helpers_enrollments
+from canvas_api.helpers import enrollments as canvas_api_helpers_enrollments
 
 logger = logging.getLogger(__name__)
 

--- a/selenium_tests/lti_emailer/emailer_base_test_case.py
+++ b/selenium_tests/lti_emailer/emailer_base_test_case.py
@@ -14,7 +14,7 @@ from canvas_sdk.methods.external_tools \
             create_external_tool_courses,
             delete_external_tool_courses)
 from canvas_sdk.exceptions import CanvasAPIError
-from icommons_common.canvas_utils import SessionInactivityExpirationRC
+from canvas_api.canvas_utils import SessionInactivityExpirationRC
 
 SDK_CONTEXT = SessionInactivityExpirationRC(**settings.CANVAS_SDK_SETTINGS)
 

--- a/selenium_tests/lti_emailer/emailer_base_test_case.py
+++ b/selenium_tests/lti_emailer/emailer_base_test_case.py
@@ -14,9 +14,9 @@ from canvas_sdk.methods.external_tools \
             create_external_tool_courses,
             delete_external_tool_courses)
 from canvas_sdk.exceptions import CanvasAPIError
-from canvas_api.canvas_utils import SessionInactivityExpirationRC
+from canvas_sdk.client import RequestContext
 
-SDK_CONTEXT = SessionInactivityExpirationRC(**settings.CANVAS_SDK_SETTINGS)
+SDK_CONTEXT = RequestContext(**settings.CANVAS_SDK_SETTINGS)
 
 logger = logging.getLogger(__name__)
 logging.basicConfig()


### PR DESCRIPTION
- Updated to use our org [canvas_python_sdk](https://github.com/Harvard-University-iCommons/canvas_python_sdk)
- Replaced the references to SessionInactivityExpirationRC with RequestContext from canvas_python_sdk
- Removed `'session_inactivity_expiration_time_secs': 50` setting from [lti_emailer/settings/base.py](https://github.com/Harvard-University-iCommons/lti_emailer/commit/7380835fb364bae572b192175fe1ae10be55964f#diff-6ef077b832bd2e47795f722ed389421ba173176ed18b04820f15d77205a32adf)

Note: Deployed in QA (Canvas beta)