### PR TITLE
Task/haydn9000/tlt 4531/update libraries for lti school permission

### DIFF
--- a/lti_emailer/management/commands/report_user_primary_email.py
+++ b/lti_emailer/management/commands/report_user_primary_email.py
@@ -5,14 +5,14 @@ import os
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
-from icommons_common.models import Term, CourseInstance
+from coursemanager.models import Term, CourseInstance
 
 from canvas_sdk.utils import get_all_list_data
 from canvas_sdk.methods.courses import list_users_in_course_users
 from canvas_sdk.exceptions import CanvasAPIError
 
 from canvas_sdk.client import RequestContext
-from icommons_common.models import Person
+from coursemanager.people_models import Person
 
 
 SDK_CONTEXT = RequestContext(**settings.CANVAS_SDK_SETTINGS)

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -20,5 +20,5 @@ git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0#egg=django-auth-lti==2.1.0
 git+https://github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.6#egg=django-ssm-parameter-store==0.6
 git+ssh://git@github.com/Harvard-University-iCommons/harvard-django-utils.git@v0.1#harvard-django-utils==0.1
-git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@task/haydn9000/TLT-4531/update-model-to-resole-warning#egg=django-coursemanager
+git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.6#egg=django-coursemanager==0.6
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v3.2#egg=django-canvas-lti-school-permissions==3.2

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -20,5 +20,5 @@ git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0#egg=django-auth-lti==2.1.0
 git+https://github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.6#egg=django-ssm-parameter-store==0.6
 git+ssh://git@github.com/Harvard-University-iCommons/harvard-django-utils.git@v0.1#harvard-django-utils==0.1
-git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.5#egg=django-coursemanager==0.5
+git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@task/haydn9000/TLT-4531/update-model-to-resole-warning#egg=django-coursemanager
 git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v3.2#egg=django-canvas-lti-school-permissions==3.2

--- a/lti_emailer/requirements/base.txt
+++ b/lti_emailer/requirements/base.txt
@@ -19,4 +19,6 @@ git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-common.git@
 git+ssh://git@github.com/Harvard-University-iCommons/django-icommons-ui.git@v2.1#egg=django-icommons-ui==2.1
 git+ssh://git@github.com/Harvard-University-iCommons/django-auth-lti.git@v2.1.0#egg=django-auth-lti==2.1.0
 git+https://github.com/Harvard-University-iCommons/django-ssm-parameter-store.git@v0.6#egg=django-ssm-parameter-store==0.6
-git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v2.0#egg=django-canvas-lti-school-permissions==2.0
+git+ssh://git@github.com/Harvard-University-iCommons/harvard-django-utils.git@v0.1#harvard-django-utils==0.1
+git+ssh://git@github.com/Harvard-University-iCommons/django-coursemanager.git@v0.5#egg=django-coursemanager==0.5
+git+ssh://git@github.com/Harvard-University-iCommons/django-canvas-lti-school-permissions@v3.2#egg=django-canvas-lti-school-permissions==3.2

--- a/lti_emailer/settings/base.py
+++ b/lti_emailer/settings/base.py
@@ -112,6 +112,7 @@ DATABASES = {
     }
 }
 
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 COURSE_SCHEMA_DB_NAME = 'coursemanager'
 
 # Cache

--- a/lti_emailer/settings/base.py
+++ b/lti_emailer/settings/base.py
@@ -31,12 +31,11 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django_auth_lti',
-    'icommons_common',
+    'coursemanager',
     'lti_permissions',
     'icommons_ui',
     'djng',
     'lti_emailer',
-    'coursemanager',
     'lti_school_permissions',
     'mailing_list',
     'mailgun',
@@ -88,7 +87,7 @@ WSGI_APPLICATION = 'lti_emailer.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/2.2/ref/settings/#databases
 
-DATABASE_ROUTERS = ['icommons_common.routers.CourseSchemaDatabaseRouter']
+DATABASE_ROUTERS = ['coursemanager.routers.CourseSchemaDatabaseRouter']
 
 DATABASES = {
     'default': {
@@ -300,7 +299,7 @@ LOGGING = {
             'handlers': ['default'],
             'propagate': False,
         },
-        'icommons_common': {
+        'coursemanager': {
            'handlers': ['default'],
            'level': _DEFAULT_LOG_LEVEL,
            'propagate': False,

--- a/lti_emailer/settings/base.py
+++ b/lti_emailer/settings/base.py
@@ -36,6 +36,7 @@ INSTALLED_APPS = [
     'icommons_ui',
     'djng',
     'lti_emailer',
+    'coursemanager',
     'lti_school_permissions',
     'mailing_list',
     'mailgun',

--- a/mailgun/listserv_client.py
+++ b/mailgun/listserv_client.py
@@ -4,7 +4,7 @@ import json
 
 from django.conf import settings
 
-from icommons_common.utils import ApiRequestTimer
+from harvard_django_utils.utils import ApiRequestTimer
 
 from lti_emailer.exceptions import ListservApiError
 from mailgun.utils import replace_non_ascii

--- a/mailgun/route_handlers.py
+++ b/mailgun/route_handlers.py
@@ -11,7 +11,7 @@ from django.template.loader import get_template
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 from flanker.addresslib import address as addresslib_address
-from icommons_common.models import CourseInstance
+from coursemanager.models import CourseInstance
 
 from lti_emailer.canvas_api_client import (get_alternate_emails_for_user_email,
                                            get_name_for_email)

--- a/mailgun/tests.py
+++ b/mailgun/tests.py
@@ -13,7 +13,7 @@ from django.test import TestCase, RequestFactory
 from django.test.utils import override_settings
 from mock import MagicMock, call, patch
 
-from icommons_common.utils import Bunch
+from harvard_django_utils.utils import Bunch
 
 from mailing_list.models import MailingList
 from mailgun.decorators import authenticate

--- a/mailing_list/api.py
+++ b/mailing_list/api.py
@@ -44,7 +44,7 @@ def lists(request):
         logger.exception(message)
         return JsonResponse({'error': message}, status=500)
 
-    return JsonResponse(mailing_lists, status=200)
+    return JsonResponse(mailing_lists, safe=False, status=200)
 
 
 @login_required

--- a/mailing_list/api.py
+++ b/mailing_list/api.py
@@ -1,20 +1,17 @@
-import logging
 import json
+import logging
 
 from django.conf import settings
-from django.views.decorators.http import require_http_methods
 from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.core.exceptions import PermissionDenied
-
-from django_auth_lti.decorators import lti_role_required
+from django.http import JsonResponse
+from django.views.decorators.http import require_http_methods
 from django_auth_lti import const
-
-from icommons_common.view_utils import create_json_200_response, create_json_500_response
+from django_auth_lti.decorators import lti_role_required
 from lti_school_permissions.decorators import lti_permission_required
 
-from .models import MailingList, CourseSettings
-
+from .models import CourseSettings, MailingList
 
 logger = logging.getLogger(__name__)
 
@@ -45,9 +42,9 @@ def lists(request):
     except Exception:
         message = "Failed to get_or_create MailingLists with LTI params %s" % json.dumps(request.LTI)
         logger.exception(message)
-        return create_json_500_response(message)
+        return JsonResponse({'error': message}, status=500)
 
-    return create_json_200_response(mailing_lists)
+    return JsonResponse(mailing_lists, status=200)
 
 
 @login_required
@@ -87,9 +84,9 @@ def set_access_level(request, mailing_list_id):
     except Exception:
         message = "Failed to activate MailingList %s with LTI params %s" % (mailing_list_id, json.dumps(request.LTI))
         logger.exception(message)
-        return create_json_500_response(message)
+        return JsonResponse({'error': message}, status=500)
 
-    return create_json_200_response(result)
+    return JsonResponse(result, status=200)
 
 
 @login_required
@@ -125,11 +122,11 @@ def get_or_create_course_settings(request):
     except Exception:
         message = "Failed to get_or_create CourseSettings for course %s" % canvas_course_id
         logger.exception(message)
-        return create_json_500_response(message)
+        return JsonResponse({'error': message}, status=500)
 
     result = {
         'canvas_course_id': course_settings.canvas_course_id,
         'always_mail_staff': course_settings.always_mail_staff,
     }
 
-    return create_json_200_response(result)
+    return JsonResponse(result, status=200)

--- a/mailing_list/tests/test_util_methods.py
+++ b/mailing_list/tests/test_util_methods.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from mock import patch
 
 from mailing_list.utils import get_section_sis_enrollment_status, is_course_crosslisted
-from icommons_common.models import CourseInstance, XlistMap
+from coursemanager.models import CourseInstance, XlistMap
 
 
 class CourseInstanceStub:

--- a/mailing_list/utils.py
+++ b/mailing_list/utils.py
@@ -1,6 +1,6 @@
 import logging
 
-from icommons_common.models import CourseInstance, XlistMap
+from coursemanager.models import CourseInstance, XlistMap
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
- Bumped `django-canvas-lti-school-permissions` to `v3.2` and added required libraries
- Added `coursemanager` in installed apps
- Removed `icommons_common`
- Using Django JsonResponse instead of icommons_common > view_utils `create_json_200_response` and `create_json_500_response` functions in `mailing_list/api.py`
- Fixed warning about configuring the DEFAULT_AUTO_FIELD


Note:
- Deployed in DEV
- Updated  [django-coursemanager](https://github.com/Harvard-University-iCommons/django-coursemanager) to resolve one of the warning, [see PR here](https://github.com/Harvard-University-iCommons/django-coursemanager/pull/6).