### PR TITLE
Refactor and update usage report mgmt to support all schools

### DIFF
--- a/mailing_list/management/commands/README.md
+++ b/mailing_list/management/commands/README.md
@@ -1,13 +1,33 @@
 # generate_course_emailer_report.py
-- `generate_course_emailer_report` is a Django management command designed to create a CSV report of courses that have utilized the Course Emailer tool within a specified school and academic years.
-- To run this management command, you can use the following command:
-    ```
-    python manage.py generate_course_emailer_report --school <school_id> --academic-years <academic_year1> <academic_year2> --output-file <output_file>
-    ```
-    - `--school`: Required argument to specify the Canvas account school ID, e.g., "hsph".
-    - `--academic-years`: Required argument to provide a list of academic years, e.g., "2023 2024".
-    - `--output-file`: Optional argument to specify the path of the output CSV file. If not provided, the default path is "./mailing_list/management/commands/report.csv".
-    - Example:
-        ```
-        python manage.py generate_course_emailer_report --school hsph --academic-years 2023 2024
-        ```
+
+- `generate_course_emailer_report` is a Django management command designed to create a CSV report of courses that have utilized the Course Emailer tool.
+- The report includes course details such as school ID, course ID, Canvas course ID, term ID, title, instructors, and cross-listing status.
+
+### Arguments
+
+- `--academic-years`: **Required** - Specify one or more academic years for which to generate the report (e.g., "2024 2025").
+
+- `--school`: Optional - Specify the Canvas account school ID (e.g., "hls"). If not provided, courses from all schools will be included in the report.
+
+- `--include-ongoing`: Optional flag - Include ongoing courses (with academic year value of 1900) in the report.
+
+- `--output-file`: Optional - Specify the path for the output CSV file. If not provided, the default path is "./mailing_list/management/commands/report.csv".
+
+### Examples commands
+
+1. Generate a report for a specific school and academic years:
+```
+python manage.py generate_course_emailer_report --school hsph --academic-years 2024 2025
+```
+2. Generate a report for all schools in a specific academic year:
+```
+python manage.py generate_course_emailer_report --academic-years 2025
+```
+3. Include ongoing courses in the report:
+```
+python manage.py generate_course_emailer_report --academic-years 2025 --include-ongoing
+```
+4. Specify a custom output file:
+```
+python manage.py generate_course_emailer_report --academic-years 2025 --output-file /path/to/custom_report.csv
+```

--- a/mailing_list/management/commands/generate_course_emailer_report.py
+++ b/mailing_list/management/commands/generate_course_emailer_report.py
@@ -1,8 +1,11 @@
 import csv
 import logging
+from argparse import ArgumentParser
+from typing import Any, Dict
 
 from coursemanager.models import CourseInstance
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
 
 from mailing_list.models import MailingList
 
@@ -10,44 +13,80 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = 'Generates a CSV report of courses that have utilized the \
-            Course Emailer tool within a specified school and academic years.'
+    help = 'Generates a CSV report of courses that have used the Course Emailer tool. \
+            Filters by academic years (required), school (optional), and can include \
+            ongoing courses. Output includes course details such as school ID, course ID, \
+            Canvas course ID, term ID, title, instructors, and cross-listing status.'
 
-    def add_arguments(self, parser):
+    ONGOING_TERM_YEAR = '1900'
+    DEFAULT_OUTPUT_FILE = './mailing_list/management/commands/report.csv'
+
+    def add_arguments(self, parser: ArgumentParser) -> None:
         """ Command-line argument definitions."""
-        parser.add_argument('--school', required=True,
-                            help='Canvas account school id (e.g. hls)')
+        parser.add_argument('--school', required=False,
+                            help='Canvas account school id (e.g. hls). If not provided, all schools will be included.')
         parser.add_argument('--academic-years', nargs='+', required=True,
-                            help='Canvas enrollment academic year (e.g. 2023)')
-        parser.add_argument('--output-file',
+                            help='Canvas enrollment academic year (e.g. 2025)')
+        parser.add_argument('--include-ongoing', action='store_true',
+                            help='Include ongoing courses (with academic year value of 1900)')
+        parser.add_argument('--output-file', required=False,
                             help='File to output mailing list details to')
 
-    def handle(self, *args, **options) -> None:
+    def handle(self, *args: Any, **options: Dict[str, Any]) -> None:
         """
         Generates a CSV report of courses that have utilized the \
         Course Emailer tool within a specified school and academic years.
         """
         # Retrieve command-line arguments
-        school = options['school']
+        school = options.get('school')
         academic_years = options['academic_years']
-        output_file = options['output_file'] if options['output_file'] else './mailing_list/management/commands/report.csv'
+        include_ongoing = options.get('include_ongoing', False)
+        output_file = options['output_file'] if options['output_file'] else self.DEFAULT_OUTPUT_FILE
 
+        # Validate academic years
+        for year in academic_years:
+            try:
+                int(year)
+            except ValueError:
+                raise CommandError(f"Invalid academic year: {year}. Years must be integers.")
+
+        earliest_academic_year = min(int(year) for year in academic_years)
+        start_date = timezone.datetime(earliest_academic_year, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        
         # Retrieve canvas course ids in mailing list. Mailing list records are
         # created in the database once a course start using the Course Emailer tool.
         canvas_course_id_list = list(MailingList.objects.filter(
-            date_created__gte='2022-01-01 00:00:00').values_list('canvas_course_id', flat=True))
-        print(f"======>>> canvas_course_id_list total: {len(canvas_course_id_list)}")
+            date_created__gte=start_date).values_list('canvas_course_id', flat=True).distinct())
+        print(f"======>>> Canvas course ID list since {earliest_academic_year} from mailing list. Total: {len(canvas_course_id_list)}")
+        # Build query filters
+        query_filters = {
+            'canvas_course_id__in': canvas_course_id_list,
+            'sync_to_canvas': 1
+        }
 
-        # Query CourseInstance based on school, academic years, and terms
-        course_instances = CourseInstance.objects.filter(
-            course__school_id=school, term__academic_year__in=academic_years,
-            canvas_course_id__in=canvas_course_id_list, sync_to_canvas=1)
-        print(f"======>>> course_instances total: {len(course_instances)}")
+        # Add academic year filter
+        if include_ongoing:
+            query_filters['term__academic_year__in'] = academic_years + [self.ONGOING_TERM_YEAR]
+            print(f"======>>> Including ongoing term ({self.ONGOING_TERM_YEAR}) in academic years.")
+        else:
+            query_filters['term__academic_year__in'] = academic_years
+        
+        # Add school filter only if a specific school is provided
+        if school:
+            query_filters['course__school_id'] = school
+            school_message = f"for school '{school}'"
+        else:
+            school_message = "for all schools"
+        
+        # Query CourseInstance based on filters
+        course_instances = CourseInstance.objects.filter(**query_filters)
+        print(f"======>>> Total course instances using Course Emailer {school_message}: {len(course_instances)}")
 
         # Iterate through course instances and collect relevant data.
         course_data = []
         for course_instance in course_instances:
-            course_data.append([course_instance.course_instance_id,
+            course_data.append([course_instance.course.school_id,
+                                course_instance.course_instance_id,
                                 course_instance.canvas_course_id,
                                 course_instance.term_id,
                                 course_instance.title,
@@ -55,16 +94,24 @@ class Command(BaseCommand):
                                 course_instance.xlist_flag])
 
         # Define the fields for the CSV.
-        OUTPUT_FIELDS = ['course_instance_id', 'canvas_course_id', 'term_id',
-                         'title', 'instructors_display', 'xlist_flag']
+        OUTPUT_FIELDS = ['school_id', 'course_instance_id', 'canvas_course_id',
+                         'term_id', 'title', 'instructors_display', 'xlist_flag']
 
         # Save data to CSV file.
         if course_data:
-            with open(output_file, 'w', newline='') as csv_file:
-                csv_writer = csv.writer(csv_file)
-                csv_writer.writerow(OUTPUT_FIELDS)
-                csv_writer.writerows(course_data)
+            try:
+                with open(output_file, 'w', newline='') as csv_file:
+                    csv_writer = csv.writer(csv_file)
+                    csv_writer.writerow(OUTPUT_FIELDS)
+                    csv_writer.writerows(course_data)
 
-            self.stdout.write(self.style.SUCCESS(f"CSV report has been generated and saved to {output_file}"))
+                self.stdout.write(self.style.SUCCESS(f"CSV report has been generated and saved to {output_file}"))
+            except IOError as e:
+                self.stdout.write(self.style.ERROR(f"Error writing to file {output_file}: {str(e)}"))
         else:
-            self.stdout.write(self.style.ERROR(f"ERROR CSV report has NOT been generated."))
+            school_filter = f"school '{school}'" if school else "all schools"
+            years_str = ", ".join(academic_years)
+            ongoing_str = "including ongoing courses" if include_ongoing else "excluding ongoing courses"
+            self.stdout.write(self.style.WARNING(
+                f"No data found for {school_filter} in academic years {years_str} ({ongoing_str})."
+            ))

--- a/mailing_list/management/commands/generate_course_emailer_report.py
+++ b/mailing_list/management/commands/generate_course_emailer_report.py
@@ -51,7 +51,7 @@ class Command(BaseCommand):
                 raise CommandError(f"Invalid academic year: {year}. Years must be integers.")
 
         earliest_academic_year = min(int(year) for year in academic_years)
-        start_date = timezone.datetime(earliest_academic_year, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        start_date = timezone.datetime(earliest_academic_year, 8, 1, 0, 0, 0, tzinfo=timezone.utc)
         
         # Retrieve canvas course ids in mailing list. Mailing list records are
         # created in the database once a course start using the Course Emailer tool.


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [x] Feature
- [ ] Bug Fix
- [x] Optimization
- [x] Documentation Update

## Description

LIT Emailer:
- Added support to generate usage report for all schools when the `--school` parameter is not specified.
- Added support for ongoing courses via the `--include-ongoing flag`, which includes courses with academic year `1900`.
- Refactored and optimized code for better readability and maintainability.
- Updated README with usage examples and parameter descriptions.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).
-->

- Closes [TLT-5046](https://at-harvard.atlassian.net/browse/TLT-5046)
- Related Issue(s) #

## QA Instructions, Screenshots, Recordings

None

## Regression Testing

- ✅ Verified command execution with various parameter combinations, including:
    - Filtering by a specific school
    - Generating reports for all schools
    - Single and multiple academic years
    - Including/excluding ongoing courses
    - Custom output file paths
    - All scenarios successfully generated properly filtered CSV reports with appropriate field columns.

## [optional] Are there any post deployment tasks we need to perform?

None