### PR TITLE
Add AWS_S3_CUSTOM_DOMAIN setting

### DIFF
--- a/lti_emailer/settings/aws.py
+++ b/lti_emailer/settings/aws.py
@@ -21,6 +21,7 @@ STATICFILES_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
 AWS_STORAGE_BUCKET_NAME = SECURE_SETTINGS.get("static_files_s3_bucket")
 AWS_QUERYSTRING_AUTH = False
 AWS_LOCATION = SECURE_SETTINGS.get("static_files_s3_prefix")
+AWS_S3_CUSTOM_DOMAIN = "static.tlt.harvard.edu"
 AWS_DEFAULT_ACL = None
 
 # SSL is terminated at the ELB so look for this header to know that we should be in ssl mode


### PR DESCRIPTION
Add AWS_S3_CUSTOM_DOMAIN setting to `aws.py` so that staticfiles requests will go through CloudFront instead of directly to the bucket. 